### PR TITLE
Narrow scope to OpenAI, Anthropic, Google + add deprecation sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ GitHub Composite Action that scans repositories for LLM model references and cre
 
 ## What it does
 
-1. **Scans** source code and config files for LLM model references (OpenAI, Anthropic, Google, Meta, Mistral, Cohere, DeepSeek, xAI)
-2. **Detects** deprecated/retiring/shutdown models (e.g. gpt-4o, gpt-3.5-turbo, o1-preview, text-embedding-ada-002)
+1. **Scans** source code and config files for LLM model references (OpenAI, Anthropic, Google)
+2. **Detects** deprecated/retiring/shutdown models (e.g. gpt-4o, gpt-3.5-turbo, claude-3.5-sonnet, gemini-1.5-pro)
 3. **Creates GitHub Issues** for each deprecated model found, with affected files, replacement suggestions, and shutdown dates
 4. **Notifies Slack** (optional) when deprecated models are detected
 
@@ -16,13 +16,17 @@ GitHub Composite Action that scans repositories for LLM model references and cre
 | OpenAI | gpt-4.1, gpt-5, gpt-5.1, gpt-4o, gpt-4-turbo, gpt-3.5-turbo, o1/o3/o4-mini, codex-mini |
 | Anthropic | claude-opus-4, claude-sonnet-4, claude-3.5-sonnet/haiku, claude-3-opus/sonnet/haiku |
 | Google | gemini-2.5-pro/flash, gemini-2.0-flash, gemini-1.5-pro/flash, gemini-pro |
-| Meta | llama-3, llama-2, codellama |
-| Mistral | mistral-large/medium/small, mixtral, codestral |
-| Cohere | command-r-plus, command-r |
-| DeepSeek | deepseek-v3, deepseek-r1, deepseek-coder |
-| xAI | grok-2, grok-3 |
-| Embeddings | text-embedding-3-small/large, text-embedding-ada-002, embed-english-v3.0, voyage-* |
-| Frameworks | langchain, llamaindex, crewai, litellm, haystack, autogen, dspy |
+| Embeddings | text-embedding-3-small/large, text-embedding-ada-002, voyage-* |
+
+## Deprecation tracking sources
+
+The deprecation registry is maintained using these official provider pages:
+
+| Provider | Source |
+|---|---|
+| OpenAI | [Model deprecations](https://platform.openai.com/docs/deprecations) |
+| Anthropic | [Model deprecations](https://platform.claude.com/docs/en/about-claude/model-deprecations) |
+| Google | [Gemini deprecations](https://ai.google.dev/gemini-api/docs/deprecations) |
 
 ## Usage
 
@@ -75,7 +79,7 @@ jobs:
 
 | Output | Description |
 |---|---|
-| `match-count` | Total model/framework references found |
+| `match-count` | Total model references found |
 | `deprecated-count` | Number of deprecated model references |
 | `issues-created` | Number of GitHub issues created |
 | `deprecated-summary` | JSON summary of deprecated models |
@@ -93,10 +97,10 @@ pip install pytest pytest-bdd
 python -m pytest tests/ -v --rootdir=.
 ```
 
-142 BDD tests covering:
-- Pattern detection (LLM models, embeddings, frameworks, date suffixes, false positives)
+BDD tests covering:
+- Pattern detection (LLM models, embeddings, date suffixes, false positives)
 - Scanner (directory traversal, deduplication, exclusions)
-- Deprecation registry (deprecated vs active models, coherence checks)
+- Deprecation registry (deprecated vs active models, date suffix handling, coherence checks)
 - Issue reporter (title/body formatting, grouping, dry-run, assignee validation)
 - CLI orchestration (argument parsing, end-to-end pipelines)
 

--- a/src/deprecations.py
+++ b/src/deprecations.py
@@ -1,18 +1,23 @@
 """Registry of deprecated/retiring LLM models with lifecycle data.
 
 Sources:
-    https://platform.openai.com/docs/deprecations
-    https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/model-retirements
+    OpenAI: https://platform.openai.com/docs/deprecations
+    Anthropic: https://platform.claude.com/docs/en/about-claude/model-deprecations
+    Google: https://ai.google.dev/gemini-api/docs/deprecations
 """
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from datetime import date
 from typing import Literal
 
 
 DeprecationStatus = Literal["retiring", "deprecated", "shutdown"]
+
+# Matches date suffixes like -20240229, -2024-08-06, -20241022
+_DATE_SUFFIX_RE = re.compile(r"-\d{4}-?\d{2}-?\d{2}$")
 
 
 @dataclass(frozen=True)
@@ -94,6 +99,60 @@ def _build_registry() -> dict[str, ModelLifecycle]:
         note="No retirement before April 2027",
     )
 
+    # --- Anthropic: Shutdown (already retired) ---
+    _add(
+        "claude-3.5-sonnet",
+        "anthropic",
+        "shutdown",
+        "2025-10-28",
+        "claude-sonnet-4",
+        note="Both v1 (20240620) and v2 (20241022) retired",
+    )
+    _add("claude-3-opus", "anthropic", "shutdown", "2026-01-05", "claude-opus-4")
+    _add("claude-3-sonnet", "anthropic", "shutdown", "2025-07-21", "claude-sonnet-4")
+
+    # --- Anthropic: Deprecated (retirement date set) ---
+    _add(
+        "claude-3.5-haiku",
+        "anthropic",
+        "deprecated",
+        "2026-02-19",
+        "claude-haiku-4-5",
+    )
+
+    # --- Google: Retiring ---
+    _add(
+        "gemini-2.0-flash",
+        "google",
+        "retiring",
+        "2026-03-31",
+        "gemini-2.5-flash",
+    )
+    _add(
+        "gemini-1.5-pro",
+        "google",
+        "shutdown",
+        "2025-09-23",
+        "gemini-2.5-pro",
+        note="gemini-1.5-pro-001/002 retired",
+    )
+    _add(
+        "gemini-1.5-flash",
+        "google",
+        "shutdown",
+        "2025-09-23",
+        "gemini-2.5-flash",
+        note="gemini-1.5-flash-001/002 retired",
+    )
+    _add(
+        "gemini-pro",
+        "google",
+        "shutdown",
+        "2025-02-15",
+        "gemini-2.5-pro",
+        note="Original Gemini 1.0 Pro, retired",
+    )
+
     return registry
 
 
@@ -103,6 +162,18 @@ DEPRECATION_REGISTRY: dict[str, ModelLifecycle] = _build_registry()
 def check_deprecation(model: str) -> ModelLifecycle | None:
     """Look up deprecation info for a model.
 
+    Handles date-suffixed model names (e.g. "gpt-4o-2024-08-06" → "gpt-4o")
+    by stripping the suffix and retrying the lookup.
+
     Returns ModelLifecycle if the model is deprecated/retiring, None otherwise.
     """
-    return DEPRECATION_REGISTRY.get(model)
+    result = DEPRECATION_REGISTRY.get(model)
+    if result is not None:
+        return result
+
+    # Try stripping date suffix (e.g. "claude-3.5-sonnet-20241022" → "claude-3.5-sonnet")
+    base = _DATE_SUFFIX_RE.sub("", model)
+    if base != model:
+        return DEPRECATION_REGISTRY.get(base)
+
+    return None

--- a/src/main.py
+++ b/src/main.py
@@ -63,7 +63,7 @@ def main(argv: list[str] | None = None) -> None:
 
     # Step 1: Scan for model references
     result = scan_directory(scan_path, args.repo_name)
-    logger.info("Found %d model/framework references in %s", result.match_count, args.repo_name)
+    logger.info("Found %d model references in %s", result.match_count, args.repo_name)
 
     # Step 2: Check for deprecated models
     alerts = _find_deprecated(result.matches)

--- a/src/models.py
+++ b/src/models.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import Literal
 
 
-MatchType = Literal["llm", "embedding", "framework"]
+MatchType = Literal["llm", "embedding"]
 
 
 @dataclass(frozen=True)

--- a/src/patterns.py
+++ b/src/patterns.py
@@ -1,4 +1,4 @@
-"""Regex patterns for detecting LLM models, embeddings, and frameworks."""
+"""Regex patterns for detecting LLM models and embeddings."""
 
 from __future__ import annotations
 
@@ -23,7 +23,7 @@ class ModelPattern:
 
 # Context keywords required for short model names (e.g. "o1", "o3")
 CONTEXT_KEYWORDS: re.Pattern[str] = re.compile(
-    r"model|llm|openai|api|chat|completion|gpt|anthropic|claude|gemini|"
+    r"model|llm|openai|api|chat|completion|gpt|anthropic|claude|gemini|google|"
     r"embedding|embed|vector|provider|ai[\._\-]|engine",
     re.IGNORECASE,
 )
@@ -91,46 +91,12 @@ def _build_patterns() -> list[ModelPattern]:
     _add("google", "llm", r"\bgemini-1[\.-]5-flash(?:-\d{3})?\b")
     _add("google", "llm", r"\bgemini-pro\b")
 
-    # --- DeepSeek ---
-    _add("deepseek", "llm", r"\bdeepseek-(?:v3|r1|coder)\b")
-
-    # --- xAI ---
-    _add("xai", "llm", r"\bgrok-[23]\b")
-
-    # --- Meta ---
-    _add("meta", "llm", r"\bllama-?3(?:\.?[123])?\b")
-    _add("meta", "llm", r"\bllama-?2\b")
-    _add("meta", "llm", r"\bcodellama\b")
-
-    # --- Mistral ---
-    _add("mistral", "llm", r"\bmistral-large(?:-\d{4}-\d{2}-\d{2})?\b")
-    _add("mistral", "llm", r"\bmistral-medium(?:-\d{4}-\d{2}-\d{2})?\b")
-    _add("mistral", "llm", r"\bmistral-small(?:-\d{4}-\d{2}-\d{2})?\b")
-    _add("mistral", "llm", r"\bmixtral\b")
-    _add("mistral", "llm", r"\bcodestral\b")
-
-    # --- Cohere ---
-    _add("cohere", "llm", r"\bcommand-r-plus\b")
-    _add("cohere", "llm", r"\bcommand-r\b")
-
     # --- OpenAI Embeddings ---
     _add("openai", "embedding", r"\btext-embedding-3-(?:small|large)\b")
     _add("openai", "embedding", r"\btext-embedding-ada-002\b")
 
-    # --- Cohere Embeddings ---
-    _add("cohere", "embedding", r"\bembed-(?:english|multilingual)-v[23]\.0\b")
-
     # --- Voyage Embeddings ---
     _add("voyage", "embedding", r"\bvoyage-(?:large|code|lite)-\d+\b")
-
-    # --- Frameworks ---
-    _add("langchain", "framework", r"\blangchain\b")
-    _add("llamaindex", "framework", r"\bllamaindex\b")
-    _add("haystack", "framework", r"\bhaystack\b")
-    _add("autogen", "framework", r"\bautogen\b")
-    _add("crewai", "framework", r"\bcrewai\b")
-    _add("dspy", "framework", r"\bdspy\b")
-    _add("litellm", "framework", r"\blitellm\b")
 
     return patterns
 
@@ -141,7 +107,7 @@ MODEL_PATTERNS: list[ModelPattern] = _build_patterns()
 def find_matches_in_line(
     line: str,
 ) -> list[tuple[str, str, MatchType]]:
-    """Find all model/framework matches in a single line of text.
+    """Find all model/embedding matches in a single line of text.
 
     Returns a list of (provider, model_name, match_type) tuples.
     """

--- a/tests/features/deprecations.feature
+++ b/tests/features/deprecations.feature
@@ -9,17 +9,36 @@ Feature: Model deprecation detection
     And the replacement should be "<replacement>"
 
     Examples:
-      | model               | status     | replacement           |
-      | gpt-3.5-turbo       | deprecated | gpt-4.1-mini          |
-      | gpt-4               | retiring   | gpt-4.1               |
-      | gpt-4-turbo         | retiring   | gpt-4.1               |
-      | gpt-4-turbo-preview | retiring   | gpt-4.1               |
-      | gpt-4o              | retiring   | gpt-4.1               |
-      | gpt-4o-mini         | retiring   | gpt-4.1-mini          |
-      | o1                  | retiring   | o3                    |
-      | o1-preview          | shutdown   | o3                    |
-      | o1-mini             | shutdown   | o4-mini               |
-      | text-embedding-ada-002 | retiring | text-embedding-3-small |
+      | model                  | status     | replacement           |
+      | gpt-3.5-turbo          | deprecated | gpt-4.1-mini          |
+      | gpt-4                  | retiring   | gpt-4.1               |
+      | gpt-4-turbo            | retiring   | gpt-4.1               |
+      | gpt-4-turbo-preview    | retiring   | gpt-4.1               |
+      | gpt-4o                 | retiring   | gpt-4.1               |
+      | gpt-4o-mini            | retiring   | gpt-4.1-mini          |
+      | o1                     | retiring   | o3                    |
+      | o1-preview             | shutdown   | o3                    |
+      | o1-mini                | shutdown   | o4-mini               |
+      | text-embedding-ada-002 | retiring   | text-embedding-3-small |
+      | claude-3.5-sonnet      | shutdown   | claude-sonnet-4       |
+      | claude-3.5-haiku       | deprecated | claude-haiku-4-5      |
+      | claude-3-opus          | shutdown   | claude-opus-4         |
+      | claude-3-sonnet        | shutdown   | claude-sonnet-4       |
+      | gemini-2.0-flash       | retiring   | gemini-2.5-flash      |
+      | gemini-1.5-pro         | shutdown   | gemini-2.5-pro        |
+      | gemini-1.5-flash       | shutdown   | gemini-2.5-flash      |
+      | gemini-pro             | shutdown   | gemini-2.5-pro        |
+
+  Scenario Outline: Date-suffixed models match base deprecation
+    Given a model name "<model>"
+    When I check its deprecation status
+    Then the model should be "<status>"
+
+    Examples:
+      | model                      | status   |
+      | gpt-4o-2024-08-06          | retiring |
+      | claude-3.5-sonnet-20241022 | shutdown |
+      | claude-3-opus-20240229     | shutdown |
 
   Scenario Outline: Active models are not flagged
     Given a model name "<model>"
@@ -35,7 +54,9 @@ Feature: Model deprecation detection
       | o3                     |
       | o4-mini                |
       | claude-opus-4          |
+      | claude-sonnet-4        |
       | gemini-2.5-pro         |
+      | gemini-2.5-flash       |
       | text-embedding-3-small |
 
   Scenario: Scan config with deprecated models flags them

--- a/tests/features/main.feature
+++ b/tests/features/main.feature
@@ -46,9 +46,9 @@ Feature: CLI entry point and orchestration
     Given a temporary directory with the following files:
       | path                                  | content                                                                                                    |
       | config.yml                            | completion_model: "gpt-4o-mini"\nfallback_model: "gpt-4o"\nembedding_model: "text-embedding-ada-002"       |
-      | src/chatbot/chain.py                  | from langchain.chains import RetrievalQA\nllm = ChatOpenAI(model="gpt-4o-mini")                            |
-      | src/chatbot/embedding.py              | from langchain_openai import OpenAIEmbeddings\nembedding = OpenAIEmbeddings(model="text-embedding-ada-002") |
-      | tests/unit_testing/test_chain.py      | mock_llm = ChatOpenAI(model="gpt-4", temperature=0)                                                       |
+      | src/chatbot/chain.py                  | from openai import OpenAI\nllm = OpenAI(model="gpt-4o-mini")                                              |
+      | src/chatbot/embedding.py              | from openai import OpenAI\nembedding = OpenAI(model="text-embedding-ada-002")                              |
+      | tests/unit_testing/test_chain.py      | mock_llm = OpenAI(model="gpt-4", temperature=0)                                                           |
     When I scan and check deprecations for repo "librairies-martin-chatbot"
     Then I should find at least 4 deprecated references
     And deprecated models should include "gpt-4o-mini"
@@ -61,7 +61,7 @@ Feature: CLI entry point and orchestration
       | path                                              | content                                                          |
       | apps/backend/src/yvan/containers/config.py        | model: ClassVar[str] = "gpt-5.1"                                 |
       | apps/backend/src/yvan/infra/embedding/openai.py   | embedding_model = "text-embedding-3-large"                       |
-      | apps/backend/pyproject.toml                       | [tool.poetry.dependencies]\nlangchain = "^0.3"                   |
+      | apps/backend/pyproject.toml                       | [tool.poetry.dependencies]\nopenai = "^1.0"                      |
     When I scan and check deprecations for repo "yvan"
     Then I should find 0 deprecated references
 

--- a/tests/features/patterns.feature
+++ b/tests/features/patterns.feature
@@ -1,5 +1,5 @@
 Feature: LLM model pattern detection
-  The scanner should detect LLM models, embeddings, and frameworks
+  The scanner should detect LLM models and embeddings
   in lines of text using regex patterns.
 
   Scenario Outline: Detect standard LLM models
@@ -27,16 +27,6 @@ Feature: LLM model pattern detection
       | model: gemini-1.5-pro            | gemini-1.5-pro     | google    | llm        |
       | model = "gemini-1.5-flash"       | gemini-1.5-flash   | google    | llm        |
       | model: gemini-pro                | gemini-pro         | google    | llm        |
-      | model = "mistral-large"          | mistral-large      | mistral   | llm        |
-      | model: mistral-medium            | mistral-medium     | mistral   | llm        |
-      | model = "mistral-small"          | mistral-small      | mistral   | llm        |
-      | model: mixtral                   | mixtral            | mistral   | llm        |
-      | model = "codestral"             | codestral          | mistral   | llm        |
-      | model = "command-r-plus"         | command-r-plus     | cohere    | llm        |
-      | model: command-r                 | command-r          | cohere    | llm        |
-      | model = "llama-3"               | llama-3            | meta      | llm        |
-      | model: llama-2                   | llama-2            | meta      | llm        |
-      | model = "codellama"             | codellama          | meta      | llm        |
 
   Scenario Outline: Detect embedding models
     Given a line containing "<line>"
@@ -49,26 +39,8 @@ Feature: LLM model pattern detection
       | embedding = "text-embedding-3-small"       | text-embedding-3-small    | openai   |
       | model: text-embedding-3-large              | text-embedding-3-large    | openai   |
       | model = "text-embedding-ada-002"           | text-embedding-ada-002    | openai   |
-      | model: embed-english-v3.0                  | embed-english-v3.0        | cohere   |
-      | embedding = "embed-multilingual-v2.0"      | embed-multilingual-v2.0   | cohere   |
       | model = "voyage-large-2"                  | voyage-large-2            | voyage   |
       | model: voyage-code-3                       | voyage-code-3             | voyage   |
-
-  Scenario Outline: Detect frameworks
-    Given a line containing "<line>"
-    When I scan the line for matches
-    Then I should find model "<model>" from provider "<provider>"
-    And the match type should be "framework"
-
-    Examples:
-      | line                               | model       | provider   |
-      | from langchain import ChatOpenAI    | langchain   | langchain  |
-      | import llamaindex                   | llamaindex  | llamaindex |
-      | pip install crewai                  | crewai      | crewai     |
-      | from litellm import completion      | litellm     | litellm    |
-      | from haystack import Pipeline       | haystack    | haystack   |
-      | from autogen import Agent           | autogen     | autogen    |
-      | import dspy                         | dspy        | dspy       |
 
   Scenario Outline: Short model names require context keywords
     Given a line containing "<line>"
@@ -117,7 +89,6 @@ Feature: LLM model pattern detection
       | model: gpt-4-turbo-2024-04-09           | gpt-4-turbo-2024-04-09     | openai    |
       | model = "claude-3-opus-20240229"         | claude-3-opus-20240229     | anthropic |
       | model: claude-3.5-sonnet-20241022       | claude-3.5-sonnet-20241022 | anthropic |
-      | model = "mistral-large-2024-01-01"      | mistral-large-2024-01-01   | mistral   |
 
   Scenario Outline: Detect models with alternative separators
     Given a line containing "<line>"
@@ -142,20 +113,6 @@ Feature: LLM model pattern detection
       | model = "gemini-2.5-pro"        | gemini-2.5-pro     |
       | model: gemini-2.5-flash         | gemini-2.5-flash   |
 
-  Scenario Outline: Detect DeepSeek and xAI models
-    Given a line containing "<line>"
-    When I scan the line for matches
-    Then I should find model "<model>" from provider "<provider>"
-    And the match type should be "llm"
-
-    Examples:
-      | line                             | model          | provider |
-      | model = "deepseek-v3"           | deepseek-v3    | deepseek |
-      | model: deepseek-r1              | deepseek-r1    | deepseek |
-      | model = "deepseek-coder"        | deepseek-coder | deepseek |
-      | model: grok-2                   | grok-2         | xai      |
-      | model = "grok-3"               | grok-3         | xai      |
-
   Scenario Outline: No false positives on overlapping patterns
     Given a line containing "<line>"
     When I scan the line for matches
@@ -164,8 +121,6 @@ Feature: LLM model pattern detection
     Examples:
       | line                                          | count |
       | The commander reported the results            | 0     |
-      | command-response handler in the API           | 0     |
-      | llama3 without hyphen                         | 1     |
       | model = "gpt-4o" with only gpt-4o            | 1     |
 
   Scenario: gpt-4 pattern does not match gpt-4o

--- a/tests/features/scanner.feature
+++ b/tests/features/scanner.feature
@@ -72,21 +72,18 @@ Feature: Repository file scanner
     Given a temporary directory with the following files:
       | path                                              | content                                                                                                    |
       | config.yml                                        | completion_model: "gpt-4o-mini"\nfallback_model: "gpt-4o"\nembedding_model: "text-embedding-ada-002"       |
-      | pyproject.toml                                    | [tool.poetry.dependencies]\nlangchain = "^0.3"\nlangchain-openai = "^0.2"                                  |
-      | src/chatbot/chain.py                              | from langchain.chains import RetrievalQA\nllm = ChatOpenAI(model="gpt-4o-mini")                            |
-      | src/chatbot/vectorstore.py                        | from langchain.vectorstores import Chroma                                                                  |
-      | src/chatbot/embedding.py                          | from langchain_openai import OpenAIEmbeddings\nembedding = OpenAIEmbeddings(model="text-embedding-ada-002") |
-      | src/chatbot/bot.py                                | from langchain.callbacks import StreamingStdOutCallbackHandler                                             |
-      | tests/unit_testing/test_chain.py                  | mock_llm = ChatOpenAI(model="gpt-4", temperature=0)                                                       |
+      | pyproject.toml                                    | [tool.poetry.dependencies]\nopenai = "^1.0"                                                                |
+      | src/chatbot/chain.py                              | from openai import OpenAI\nllm = OpenAI(model="gpt-4o-mini")                                              |
+      | src/chatbot/embedding.py                          | from openai import OpenAI\nembedding = OpenAI(model="text-embedding-ada-002")                              |
+      | tests/unit_testing/test_chain.py                  | mock_llm = OpenAI(model="gpt-4", temperature=0)                                                           |
       | tests/unit_testing/test_callbacks.py              | model = "gpt-4o-mini"                                                                                      |
       | CHANGELOG.md                                      | ## v1.0\n- Migrated from gpt-4 to gpt-4o-mini                                                             |
     When I scan the directory for repo "librairies-martin-chatbot"
-    Then I should find at least 10 scan matches
+    Then I should find at least 6 scan matches
     And the results should contain model "gpt-4o-mini"
     And the results should contain model "gpt-4o"
     And the results should contain model "text-embedding-ada-002"
     And the results should contain model "gpt-4"
-    And the results should contain provider "langchain"
 
   Scenario: Broad test - yvan full project structure
     Given a temporary directory with the following files:
@@ -94,31 +91,29 @@ Feature: Repository file scanner
       | apps/backend/src/yvan/containers/config.py        | model: ClassVar[str] = "gpt-5.1"\ntemperature: float = 0.7                                       |
       | apps/backend/src/yvan/infra/embedding/openai.py   | from openai import OpenAI\nembedding_model = "text-embedding-3-large"                            |
       | apps/backend/src/yvan/infra/llm/openai_llm.py     | client = OpenAI()\nresponse = client.chat.completions.create(model="gpt-5.1")                    |
-      | apps/backend/pyproject.toml                       | [tool.poetry.dependencies]\nlangchain = "^0.3"                                                   |
+      | apps/backend/pyproject.toml                       | [tool.poetry.dependencies]\nopenai = "^1.0"                                                      |
       | apps/backend/CHANGELOG.md                         | ## v2.0\n- Upgraded to gpt-5-chat from gpt-4o                                                   |
       | apps/frontend/package.json                        | {"dependencies": {"next": "14.0"}}                                                               |
     When I scan the directory for repo "yvan"
-    Then I should find at least 5 scan matches
+    Then I should find at least 4 scan matches
     And the results should contain model "gpt-5.1"
     And the results should contain model "text-embedding-3-large"
     And the results should contain model "gpt-5-chat"
-    And the results should contain provider "langchain"
 
   Scenario: Broad test - mixed project with deprecated and active models
     Given a temporary directory with the following files:
       | path                    | content                                                                                              |
       | config/llm.yml          | primary_model: "gpt-4.1"\nfallback_model: "gpt-4o"\nlegacy_model: "gpt-3.5-turbo"                    |
       | config/embeddings.yml   | model: "text-embedding-3-small"\nlegacy: "text-embedding-ada-002"                                    |
-      | src/agent.py            | from langchain_openai import ChatOpenAI\nllm = ChatOpenAI(model="gpt-4.1-mini")                      |
-      | src/rag/retriever.py    | from langchain.vectorstores import FAISS\nembeddings = OpenAIEmbeddings(model="text-embedding-3-small") |
+      | src/agent.py            | from openai import OpenAI\nllm = OpenAI(model="gpt-4.1-mini")                                        |
+      | src/rag/retriever.py    | embedding = OpenAI(model="text-embedding-3-small")                                                    |
       | src/legacy/old_bot.py   | model = "o1-preview"\nfallback = "gpt-4-turbo"                                                       |
       | docker-compose.yml      | environment:\n  - MODEL_NAME=claude-sonnet-4\n  - EMBEDDING=text-embedding-3-large                   |
     When I scan the directory for repo "mixed-project"
-    Then I should find at least 9 scan matches
+    Then I should find at least 8 scan matches
     And the results should contain model "gpt-4.1"
     And the results should contain model "gpt-4o"
     And the results should contain model "gpt-3.5-turbo"
     And the results should contain model "o1-preview"
     And the results should contain model "gpt-4-turbo"
     And the results should contain model "claude-sonnet-4"
-    And the results should contain provider "langchain"

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -46,9 +46,3 @@ def check_scan_match_at_least(scan_result: ScanResult, count: int) -> None:
     )
 
 
-@then(
-    parsers.cfparse('the results should contain provider "{provider}"'),
-)
-def check_result_contains_provider(scan_result: ScanResult, provider: str) -> None:
-    providers = [m.provider for m in scan_result.matches]
-    assert provider in providers, f"Expected provider '{provider}' in {providers}"


### PR DESCRIPTION
## Summary
- Remove Meta, Mistral, Cohere, DeepSeek, xAI, and Frameworks from scanner scope
- Focus on OpenAI, Anthropic, and Google providers only
- Add Anthropic and Google deprecation entries with official sources
- Add date-suffix fallback in `check_deprecation()` (e.g. `claude-3.5-sonnet-20241022` resolves to `claude-3.5-sonnet`)
- Add deprecation tracking sources table to README

## Test plan
- [x] 136 BDD tests pass
- [x] Coherence test validates all deprecated models are detectable
- [x] Date-suffix deprecation lookup tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)