### PR TITLE
refactor: decouple feed fetch from scan pipeline

### DIFF
--- a/.github/workflows/update-registry.yml
+++ b/.github/workflows/update-registry.yml
@@ -1,0 +1,44 @@
+name: Mise a jour du registre de deprecation
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"  # Chaque lundi a 06:00 UTC (filtre aux semaines paires)
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ignorer les semaines impaires (execution aux 2 semaines)
+        if: github.event_name == 'schedule'
+        run: |
+          week=$(date +%V)
+          if [ $((week % 2)) -ne 0 ]; then
+            echo "Semaine impaire $week, on passe"
+            exit 1
+          fi
+
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Mettre a jour le registre depuis deprecations.info
+        run: python -m src.update_registry
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Commiter si modifie
+        run: |
+          git diff --quiet data/registry.json && exit 0
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add data/registry.json
+          git commit -m "chore: mise a jour du registre depuis deprecations.info"
+          git push

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+      - id: check-json
+      - id: check-merge-conflicts
+      - id: detect-private-key
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.6
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format

--- a/README.md
+++ b/README.md
@@ -5,9 +5,21 @@ GitHub Composite Action that scans repositories for LLM model references and cre
 ## What it does
 
 1. **Scans** source code and config files for LLM model references (OpenAI, Anthropic, Google)
-2. **Detects** deprecated/retiring/shutdown models (e.g. gpt-4o, gpt-3.5-turbo, claude-3.5-sonnet, gemini-1.5-pro)
+2. **Checks** against a JSON deprecation registry (`data/registry.json`) for deprecated/retiring/shutdown models
 3. **Creates GitHub Issues** for each deprecated model found, with affected files, replacement suggestions, and shutdown dates
 4. **Notifies Slack** (optional) when deprecated models are detected
+
+## Data sources
+
+| Source | Description |
+|---|---|
+| `data/registry.json` | JSON registry of deprecated models, committed in the repo |
+| [deprecations.info](https://deprecations.info/) | Live feed merged into the registry every two weeks via GitHub Actions |
+| [OpenAI deprecations](https://platform.openai.com/docs/deprecations) | Official OpenAI source |
+| [Anthropic deprecations](https://platform.claude.com/docs/en/about-claude/model-deprecations) | Official Anthropic source |
+| [Google deprecations](https://ai.google.dev/gemini-api/docs/deprecations) | Official Google source |
+
+The registry is updated every two weeks by `.github/workflows/update-registry.yml`. The scan pipeline reads from the local JSON file only — no network calls at scan time. If the feed is unreachable, a GitHub issue is automatically created.
 
 ## Supported models
 
@@ -17,16 +29,6 @@ GitHub Composite Action that scans repositories for LLM model references and cre
 | Anthropic | claude-opus-4, claude-sonnet-4, claude-3.5-sonnet/haiku, claude-3-opus/sonnet/haiku |
 | Google | gemini-2.5-pro/flash, gemini-2.0-flash, gemini-1.5-pro/flash, gemini-pro |
 | Embeddings | text-embedding-3-small/large, text-embedding-ada-002, voyage-* |
-
-## Deprecation tracking sources
-
-The deprecation registry is maintained using these official provider pages:
-
-| Provider | Source |
-|---|---|
-| OpenAI | [Model deprecations](https://platform.openai.com/docs/deprecations) |
-| Anthropic | [Model deprecations](https://platform.claude.com/docs/en/about-claude/model-deprecations) |
-| Google | [Gemini deprecations](https://ai.google.dev/gemini-api/docs/deprecations) |
 
 ## Usage
 
@@ -84,6 +86,20 @@ jobs:
 | `issues-created` | Number of GitHub issues created |
 | `deprecated-summary` | JSON summary of deprecated models |
 
+## Registry update
+
+The registry is updated automatically every two weeks (lundi a 06:00 UTC). You can also trigger it manually:
+
+```bash
+# Manually update the registry
+PYTHONPATH=. python -m src.update_registry
+
+# Specify a custom registry path
+PYTHONPATH=. python -m src.update_registry --registry-path data/registry.json
+```
+
+If the feed is unreachable, a GitHub issue is created with details in French, assigned to the maintainers.
+
 ## Local usage
 
 ```bash
@@ -101,17 +117,25 @@ BDD tests covering:
 - Pattern detection (LLM models, embeddings, date suffixes, false positives)
 - Scanner (directory traversal, deduplication, exclusions)
 - Deprecation registry (deprecated vs active models, date suffix handling, coherence checks)
+- Registry update (add new models, overwrite existing, empty feed handling)
 - Issue reporter (title/body formatting, grouping, dry-run, assignee validation)
 - CLI orchestration (argument parsing, end-to-end pipelines)
 
 ## Architecture
 
 ```
+data/
+  registry.json          # JSON registry of deprecated models
 src/
-  patterns.py       # Regex patterns for model detection
-  scanner.py        # Directory traversal and file scanning
-  models.py         # Data models (ScanMatch, ScanResult)
-  deprecations.py   # Deprecated model registry
-  issue_reporter.py # GitHub issue creation via gh CLI
-  main.py           # CLI entry point and orchestration
+  patterns.py            # Regex patterns for model detection
+  scanner.py             # Directory traversal and file scanning
+  models.py              # Data models (ScanMatch, ScanResult)
+  deprecations.py        # Registry loader + date suffix handling
+  deprecation_feed.py    # Feed fetcher from deprecations.info
+  update_registry.py     # Script: fetch -> merge -> save (+ issue on failure)
+  issue_reporter.py      # GitHub issue creation via gh CLI
+  main.py                # CLI entry point and orchestration
+.github/workflows/
+  ci.yml                 # CI: lint, tests, type checking
+  update-registry.yml    # Biweekly cron to update registry from feed
 ```

--- a/data/registry.json
+++ b/data/registry.json
@@ -1,0 +1,149 @@
+{
+  "updated_at": "2026-02-13T00:00:00Z",
+  "models": [
+    {
+      "model": "claude-3-opus",
+      "provider": "anthropic",
+      "status": "shutdown",
+      "shutdown_date": "2026-01-05",
+      "replacement": "claude-opus-4",
+      "note": ""
+    },
+    {
+      "model": "claude-3-sonnet",
+      "provider": "anthropic",
+      "status": "shutdown",
+      "shutdown_date": "2025-07-21",
+      "replacement": "claude-sonnet-4",
+      "note": ""
+    },
+    {
+      "model": "claude-3.5-haiku",
+      "provider": "anthropic",
+      "status": "deprecated",
+      "shutdown_date": "2026-02-19",
+      "replacement": "claude-haiku-4-5",
+      "note": ""
+    },
+    {
+      "model": "claude-3.5-sonnet",
+      "provider": "anthropic",
+      "status": "shutdown",
+      "shutdown_date": "2025-10-28",
+      "replacement": "claude-sonnet-4",
+      "note": "Both v1 (20240620) and v2 (20241022) retired"
+    },
+    {
+      "model": "gemini-1.5-flash",
+      "provider": "google",
+      "status": "shutdown",
+      "shutdown_date": "2025-09-23",
+      "replacement": "gemini-2.5-flash",
+      "note": "gemini-1.5-flash-001/002 retired"
+    },
+    {
+      "model": "gemini-1.5-pro",
+      "provider": "google",
+      "status": "shutdown",
+      "shutdown_date": "2025-09-23",
+      "replacement": "gemini-2.5-pro",
+      "note": "gemini-1.5-pro-001/002 retired"
+    },
+    {
+      "model": "gemini-2.0-flash",
+      "provider": "google",
+      "status": "retiring",
+      "shutdown_date": "2026-03-31",
+      "replacement": "gemini-2.5-flash",
+      "note": ""
+    },
+    {
+      "model": "gemini-pro",
+      "provider": "google",
+      "status": "shutdown",
+      "shutdown_date": "2025-02-15",
+      "replacement": "gemini-2.5-pro",
+      "note": "Original Gemini 1.0 Pro, retired"
+    },
+    {
+      "model": "gpt-3.5-turbo",
+      "provider": "openai",
+      "status": "deprecated",
+      "shutdown_date": "2025-09-14",
+      "replacement": "gpt-4.1-mini",
+      "note": "All gpt-3.5-turbo variants included"
+    },
+    {
+      "model": "gpt-4",
+      "provider": "openai",
+      "status": "retiring",
+      "shutdown_date": "2026-06-06",
+      "replacement": "gpt-4.1",
+      "note": ""
+    },
+    {
+      "model": "gpt-4-turbo",
+      "provider": "openai",
+      "status": "retiring",
+      "shutdown_date": "2026-06-06",
+      "replacement": "gpt-4.1",
+      "note": ""
+    },
+    {
+      "model": "gpt-4-turbo-preview",
+      "provider": "openai",
+      "status": "retiring",
+      "shutdown_date": "2026-06-06",
+      "replacement": "gpt-4.1",
+      "note": ""
+    },
+    {
+      "model": "gpt-4o",
+      "provider": "openai",
+      "status": "retiring",
+      "shutdown_date": "2026-10-01",
+      "replacement": "gpt-4.1",
+      "note": "Standard deployments retire 2026-03-31"
+    },
+    {
+      "model": "gpt-4o-mini",
+      "provider": "openai",
+      "status": "retiring",
+      "shutdown_date": "2026-10-01",
+      "replacement": "gpt-4.1-mini",
+      "note": "Standard deployments retire 2026-03-31"
+    },
+    {
+      "model": "o1",
+      "provider": "openai",
+      "status": "retiring",
+      "shutdown_date": "2026-07-15",
+      "replacement": "o3",
+      "note": ""
+    },
+    {
+      "model": "o1-mini",
+      "provider": "openai",
+      "status": "shutdown",
+      "shutdown_date": "2025-10-27",
+      "replacement": "o4-mini",
+      "note": ""
+    },
+    {
+      "model": "o1-preview",
+      "provider": "openai",
+      "status": "shutdown",
+      "shutdown_date": "2025-07-28",
+      "replacement": "o3",
+      "note": ""
+    },
+    {
+      "model": "text-embedding-ada-002",
+      "provider": "openai",
+      "status": "retiring",
+      "shutdown_date": "2027-04-15",
+      "replacement": "text-embedding-3-small",
+      "note": "No retirement before April 2027"
+    }
+  ]
+}

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,44 @@
+target-version = "py312"
+line-length = 99
+fix = true
+
+[lint]
+select = [
+    "E",     # pycodestyle errors
+    "W",     # pycodestyle warnings
+    "F",     # pyflakes
+    "I",     # isort
+    "N",     # pep8-naming
+    "UP",    # pyupgrade
+    "B",     # flake8-bugbear
+    "S",     # flake8-bandit
+    "D",     # pydocstyle
+    "ANN",   # flake8-annotations
+    "RUF",   # ruff-specific
+]
+ignore = [
+    "ANN002",  # Missing type annotation for *args
+    "ANN003",  # Missing type annotation for **kwargs
+    "D100",    # Missing docstring in public module
+    "D104",    # Missing docstring in public package
+    "E501",    # Line too long (handled by formatter)
+    "S603",    # subprocess call - check for untrusted input
+    "S607",    # Starting a process with a partial executable path
+]
+
+[lint.per-file-ignores]
+"tests/*" = [
+    "S101",    # Use of assert
+    "D100",    # Missing docstring in public module
+    "D103",    # Missing docstring in public function
+    "ANN",     # Type annotations not required in tests
+    "S108",    # Probable insecure usage of tmp
+    "ARG001",  # Unused function argument (fixtures)
+    "ARG002",  # Unused method argument
+]
+
+[lint.pydocstyle]
+convention = "google"
+
+[lint.isort]
+lines-after-imports = 2

--- a/src/deprecation_feed.py
+++ b/src/deprecation_feed.py
@@ -1,0 +1,100 @@
+"""Fetch and parse the deprecations.info live feed.
+
+Source: https://deprecations.info/v1/deprecations.json
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import urllib.request
+from datetime import UTC, date, datetime
+from typing import TYPE_CHECKING, Any
+
+
+if TYPE_CHECKING:
+    from src.deprecations import DeprecationStatus, ModelLifecycle
+
+logger = logging.getLogger(__name__)
+
+FEED_URL = "https://deprecations.info/v1/deprecations.json"
+FEED_TIMEOUT = 10
+
+# Providers we track (feed name -> internal name)
+PROVIDER_MAP: dict[str, str] = {
+    "OpenAI": "openai",
+    "Anthropic": "anthropic",
+    "Google": "google",
+    "AWS Bedrock": "aws-bedrock",
+    "Azure": "azure-openai",
+}
+
+
+def fetch_deprecations() -> list[ModelLifecycle]:
+    """Fetch deprecation data from deprecations.info.
+
+    Returns a list of ModelLifecycle objects for tracked providers.
+    Returns an empty list on any network or parsing error (silent fallback).
+    """
+    try:
+        req = urllib.request.Request(FEED_URL, headers={"User-Agent": "llm-scanner/1.0"})  # noqa: S310
+        with urllib.request.urlopen(req, timeout=FEED_TIMEOUT) as resp:  # noqa: S310
+            data: list[dict[str, Any]] = json.loads(resp.read().decode())
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        logger.warning("Could not fetch deprecation feed: %s", exc)
+        return []
+
+    return _parse_feed(data)
+
+
+def _parse_feed(data: list[dict[str, Any]]) -> list[ModelLifecycle]:
+    """Parse raw JSON entries into ModelLifecycle objects."""
+    from src.deprecations import ModelLifecycle
+
+    results: list[ModelLifecycle] = []
+    for entry in data:
+        provider_raw = entry.get("provider", "")
+        internal_provider = PROVIDER_MAP.get(provider_raw)
+        if internal_provider is None:
+            continue
+
+        model_id = entry.get("model_id", "")
+        if not model_id:
+            continue
+
+        shutdown_date = _parse_date(entry.get("shutdown_date"))
+        replacement_models = entry.get("replacement_models")
+        replacement = replacement_models[0] if replacement_models else None
+
+        # Determine status from dates
+        status: DeprecationStatus
+        today = datetime.now(tz=UTC).date()
+        if shutdown_date is not None and shutdown_date < today:
+            status = "shutdown"
+        elif shutdown_date is not None:
+            status = "retiring"
+        else:
+            status = "deprecated"
+
+        results.append(
+            ModelLifecycle(
+                model=model_id,
+                provider=internal_provider,
+                status=status,
+                shutdown_date=shutdown_date,
+                replacement=replacement,
+            )
+        )
+
+    logger.info("Fetched %d deprecations from feed (%d tracked)", len(data), len(results))
+    return results
+
+
+def _parse_date(value: str | None) -> date | None:
+    """Parse an ISO date string, returning None for empty/invalid values."""
+    if not value:
+        return None
+    try:
+        return date.fromisoformat(value)
+    except ValueError:
+        return None

--- a/src/deprecations.py
+++ b/src/deprecations.py
@@ -4,15 +4,23 @@ Sources:
     OpenAI: https://platform.openai.com/docs/deprecations
     Anthropic: https://platform.claude.com/docs/en/about-claude/model-deprecations
     Google: https://ai.google.dev/gemini-api/docs/deprecations
+    deprecations.info: https://deprecations.info/
 """
 
 from __future__ import annotations
 
+import json
+import logging
 import re
 from dataclasses import dataclass
-from datetime import date
-from typing import Literal
+from datetime import UTC, date, datetime
+from pathlib import Path
+from typing import Any, Literal
 
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_REGISTRY_PATH = Path(__file__).resolve().parent.parent / "data" / "registry.json"
 
 DeprecationStatus = Literal["retiring", "deprecated", "shutdown"]
 
@@ -32,137 +40,92 @@ class ModelLifecycle:
     note: str = ""
 
 
-def _build_registry() -> dict[str, ModelLifecycle]:
-    """Build the model deprecation registry."""
+def _entry_to_lifecycle(entry: dict[str, Any]) -> ModelLifecycle:
+    """Convert a JSON entry to a ModelLifecycle object."""
+    shutdown_str = entry.get("shutdown_date")
+    return ModelLifecycle(
+        model=entry["model"],
+        provider=entry["provider"],
+        status=entry["status"],
+        shutdown_date=date.fromisoformat(shutdown_str) if shutdown_str else None,
+        replacement=entry.get("replacement"),
+        note=entry.get("note", ""),
+    )
+
+
+def _lifecycle_to_dict(lc: ModelLifecycle) -> dict[str, Any]:
+    """Convert a ModelLifecycle object to a JSON-serializable dict."""
+    return {
+        "model": lc.model,
+        "provider": lc.provider,
+        "status": lc.status,
+        "shutdown_date": lc.shutdown_date.isoformat() if lc.shutdown_date else None,
+        "replacement": lc.replacement,
+        "note": lc.note,
+    }
+
+
+def load_registry(path: Path | None = None) -> dict[str, ModelLifecycle]:
+    """Load registry from JSON file.
+
+    Args:
+        path: Path to the registry JSON file. Defaults to data/registry.json.
+
+    Returns:
+        Dictionary mapping model names to ModelLifecycle objects.
+    """
+    registry_path = path or _DEFAULT_REGISTRY_PATH
+    try:
+        data = json.loads(registry_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("Could not load registry from %s: %s", registry_path, exc)
+        return {}
     registry: dict[str, ModelLifecycle] = {}
-
-    def _add(
-        model: str,
-        provider: str,
-        status: DeprecationStatus,
-        shutdown_date: str | None = None,
-        replacement: str | None = None,
-        note: str = "",
-    ) -> None:
-        registry[model] = ModelLifecycle(
-            model=model,
-            provider=provider,
-            status=status,
-            shutdown_date=date.fromisoformat(shutdown_date) if shutdown_date else None,
-            replacement=replacement,
-            note=note,
-        )
-
-    # --- OpenAI: Shutdown (already past end-of-life) ---
-    _add("o1-preview", "openai", "shutdown", "2025-07-28", "o3")
-    _add("o1-mini", "openai", "shutdown", "2025-10-27", "o4-mini")
-
-    # --- OpenAI: Deprecated (end-of-life approaching) ---
-    _add(
-        "gpt-3.5-turbo",
-        "openai",
-        "deprecated",
-        "2025-09-14",
-        "gpt-4.1-mini",
-        note="All gpt-3.5-turbo variants included",
-    )
-
-    # --- OpenAI: Retiring (announced, still functional) ---
-    _add("gpt-4", "openai", "retiring", "2026-06-06", "gpt-4.1")
-    _add("gpt-4-turbo", "openai", "retiring", "2026-06-06", "gpt-4.1")
-    _add("gpt-4-turbo-preview", "openai", "retiring", "2026-06-06", "gpt-4.1")
-    _add(
-        "gpt-4o",
-        "openai",
-        "retiring",
-        "2026-10-01",
-        "gpt-4.1",
-        note="Standard deployments retire 2026-03-31",
-    )
-    _add(
-        "gpt-4o-mini",
-        "openai",
-        "retiring",
-        "2026-10-01",
-        "gpt-4.1-mini",
-        note="Standard deployments retire 2026-03-31",
-    )
-    _add("o1", "openai", "retiring", "2026-07-15", "o3")
-
-    # --- OpenAI Embeddings: Retiring ---
-    _add(
-        "text-embedding-ada-002",
-        "openai",
-        "retiring",
-        "2027-04-15",
-        "text-embedding-3-small",
-        note="No retirement before April 2027",
-    )
-
-    # --- Anthropic: Shutdown (already retired) ---
-    _add(
-        "claude-3.5-sonnet",
-        "anthropic",
-        "shutdown",
-        "2025-10-28",
-        "claude-sonnet-4",
-        note="Both v1 (20240620) and v2 (20241022) retired",
-    )
-    _add("claude-3-opus", "anthropic", "shutdown", "2026-01-05", "claude-opus-4")
-    _add("claude-3-sonnet", "anthropic", "shutdown", "2025-07-21", "claude-sonnet-4")
-
-    # --- Anthropic: Deprecated (retirement date set) ---
-    _add(
-        "claude-3.5-haiku",
-        "anthropic",
-        "deprecated",
-        "2026-02-19",
-        "claude-haiku-4-5",
-    )
-
-    # --- Google: Retiring ---
-    _add(
-        "gemini-2.0-flash",
-        "google",
-        "retiring",
-        "2026-03-31",
-        "gemini-2.5-flash",
-    )
-    _add(
-        "gemini-1.5-pro",
-        "google",
-        "shutdown",
-        "2025-09-23",
-        "gemini-2.5-pro",
-        note="gemini-1.5-pro-001/002 retired",
-    )
-    _add(
-        "gemini-1.5-flash",
-        "google",
-        "shutdown",
-        "2025-09-23",
-        "gemini-2.5-flash",
-        note="gemini-1.5-flash-001/002 retired",
-    )
-    _add(
-        "gemini-pro",
-        "google",
-        "shutdown",
-        "2025-02-15",
-        "gemini-2.5-pro",
-        note="Original Gemini 1.0 Pro, retired",
-    )
-
+    for entry in data.get("models", []):
+        lc = _entry_to_lifecycle(entry)
+        registry[lc.model] = lc
     return registry
 
 
-DEPRECATION_REGISTRY: dict[str, ModelLifecycle] = _build_registry()
+def save_registry(registry: dict[str, ModelLifecycle], path: Path) -> None:
+    """Save registry to JSON file.
+
+    Sorts entries by (provider, model) for clean diffs.
+
+    Args:
+        registry: Dictionary mapping model names to ModelLifecycle objects.
+        path: Path to write the registry JSON file.
+    """
+    sorted_entries = sorted(registry.values(), key=lambda lc: (lc.provider, lc.model))
+    data = {
+        "updated_at": datetime.now(tz=UTC).isoformat(),
+        "models": [_lifecycle_to_dict(lc) for lc in sorted_entries],
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def merge_registries(
+    static: dict[str, ModelLifecycle],
+    feed: list[ModelLifecycle],
+) -> dict[str, ModelLifecycle]:
+    """Merge static registry with live feed data.
+
+    Feed entries take priority over static entries for the same model.
+    """
+    merged = dict(static)
+    for entry in feed:
+        merged[entry.model] = entry
+    return merged
+
+
+DEPRECATION_REGISTRY: dict[str, ModelLifecycle] = load_registry()
 
 
 def check_deprecation(model: str) -> ModelLifecycle | None:
     """Look up deprecation info for a model.
 
-    Handles date-suffixed model names (e.g. "gpt-4o-2024-08-06" → "gpt-4o")
+    Handles date-suffixed model names (e.g. "gpt-4o-2024-08-06" -> "gpt-4o")
     by stripping the suffix and retrying the lookup.
 
     Returns ModelLifecycle if the model is deprecated/retiring, None otherwise.
@@ -171,7 +134,7 @@ def check_deprecation(model: str) -> ModelLifecycle | None:
     if result is not None:
         return result
 
-    # Try stripping date suffix (e.g. "claude-3.5-sonnet-20241022" → "claude-3.5-sonnet")
+    # Try stripping date suffix (e.g. "claude-3.5-sonnet-20241022" -> "claude-3.5-sonnet")
     base = _DATE_SUFFIX_RE.sub("", model)
     if base != model:
         return DEPRECATION_REGISTRY.get(base)

--- a/src/issue_reporter.py
+++ b/src/issue_reporter.py
@@ -93,7 +93,7 @@ def _validate_assignees(assignees: list[str]) -> list[str] | None:
 
 def _ensure_label() -> None:
     """Create the deprecated-model label if it doesn't exist."""
-    result = subprocess.run(  # noqa: S603
+    result = subprocess.run(
         [
             "gh",
             "label",
@@ -120,7 +120,7 @@ def _issue_exists(model: str) -> bool:
         logger.warning("Suspicious model name, skipping search: %s", model)
         return False
 
-    result = subprocess.run(  # noqa: S603
+    result = subprocess.run(
         [
             "gh",
             "issue",
@@ -172,7 +172,7 @@ def _create_issue(
     if assignees:
         cmd.extend(["--assignee", ",".join(assignees)])
 
-    result = subprocess.run(  # noqa: S603
+    result = subprocess.run(
         cmd,
         capture_output=True,
         text=True,

--- a/src/update_registry.py
+++ b/src/update_registry.py
@@ -1,0 +1,131 @@
+"""Script de mise a jour du registre de deprecation depuis deprecations.info.
+
+Usage:
+    PYTHONPATH=. python -m src.update_registry [--registry-path data/registry.json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import subprocess
+from pathlib import Path
+
+from src.deprecation_feed import fetch_deprecations
+from src.deprecations import (
+    _DEFAULT_REGISTRY_PATH,
+    load_registry,
+    merge_registries,
+    save_registry,
+)
+
+
+logger = logging.getLogger(__name__)
+
+_ISSUE_LABEL = "registry-update"
+_GH_TIMEOUT = 30
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Met a jour le registre de deprecation depuis deprecations.info",
+    )
+    parser.add_argument(
+        "--registry-path",
+        type=Path,
+        default=_DEFAULT_REGISTRY_PATH,
+        help="Chemin vers le fichier JSON du registre (defaut: data/registry.json)",
+    )
+    return parser.parse_args(argv)
+
+
+def _create_feed_failure_issue(error_detail: str) -> None:
+    """Cree une issue GitHub signalant l'echec de la recuperation du flux."""
+    title = "Echec de la mise a jour du registre de deprecation"
+    body = (
+        "## Echec de la recuperation du flux deprecations.info\n\n"
+        "La mise a jour automatique du registre de deprecation a echoue.\n"
+        "Le flux [deprecations.info](https://deprecations.info/) n'a pas pu etre atteint.\n\n"
+        f"**Detail de l'erreur :** `{error_detail}`\n\n"
+        "### Actions requises\n\n"
+        "1. Verifier que le site https://deprecations.info/ est accessible\n"
+        "2. Relancer le workflow manuellement depuis l'onglet Actions\n"
+        "3. Si le probleme persiste, mettre a jour le registre manuellement "
+        "(`data/registry.json`)\n\n"
+        "---\n"
+        "*Cette issue a ete creee automatiquement par le workflow de mise a jour du registre.*"
+    )
+
+    cmd = [
+        "gh",
+        "issue",
+        "create",
+        "--title",
+        title,
+        "--body",
+        body,
+        "--label",
+        _ISSUE_LABEL,
+        "--assignee",
+        "Dpothier,jsleb333",
+    ]
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_GH_TIMEOUT,
+        )
+        if result.returncode == 0:
+            logger.info("Issue creee : %s", result.stdout.strip())
+        else:
+            logger.warning("Impossible de creer l'issue : %s", result.stderr)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        logger.warning("Erreur lors de la creation de l'issue : %s", exc)
+
+
+def update_registry(registry_path: Path) -> int:
+    """Recupere le flux, fusionne avec le registre existant et sauvegarde.
+
+    Args:
+        registry_path: Chemin vers le fichier JSON du registre.
+
+    Returns:
+        Nombre d'entrees du flux traitees.
+    """
+    current = load_registry(registry_path)
+    logger.info("Charge %d entrees depuis %s", len(current), registry_path)
+
+    feed = fetch_deprecations()
+    if not feed:
+        logger.info("Le flux n'a retourne aucune donnee, registre inchange")
+        _create_feed_failure_issue("Le flux n'a retourne aucune donnee")
+        return 0
+
+    merged = merge_registries(current, feed)
+    changes = len(merged) - len(current)
+    logger.info(
+        "Fusion : %d existants + %d flux = %d total (%+d)",
+        len(current),
+        len(feed),
+        len(merged),
+        changes,
+    )
+
+    save_registry(merged, registry_path)
+    logger.info("Registre sauvegarde dans %s", registry_path)
+    return len(feed)
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Point d'entree du script de mise a jour."""
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    args = parse_args(argv)
+    update_registry(args.registry_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/features/update_registry.feature
+++ b/tests/features/update_registry.feature
@@ -1,0 +1,23 @@
+Feature: Mise a jour du registre depuis le flux deprecations.info
+  Le script de mise a jour doit recuperer le flux, fusionner avec le
+  registre existant et sauvegarder. Les entrees du flux priment sur
+  les entrees existantes.
+
+  Scenario: La mise a jour ajoute de nouveaux modeles depuis le flux
+    Given a registry with 2 models
+    And a feed returning 1 new model "claude-3-opus" from "Anthropic"
+    When I run the registry update
+    Then the registry should have 3 models
+    And the registry should contain "claude-3-opus"
+
+  Scenario: La mise a jour ecrase un modele existant depuis le flux
+    Given a registry with model "gpt-4o" replacement "gpt-4.1"
+    And a feed returning model "gpt-4o" with replacement "gpt-5"
+    When I run the registry update
+    Then the registry entry "gpt-4o" should have replacement "gpt-5"
+
+  Scenario: Un flux vide laisse le registre inchange
+    Given a registry with 2 models
+    And a feed returning no data
+    When I run the registry update
+    Then the registry should have 2 models

--- a/tests/test_update_registry.py
+++ b/tests/test_update_registry.py
@@ -1,0 +1,136 @@
+"""BDD step definitions for registry update tests."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from pytest_bdd import given, parsers, scenarios, then, when
+from src.deprecations import ModelLifecycle, load_registry, save_registry
+from src.update_registry import update_registry
+
+
+scenarios("features/update_registry.feature")
+
+
+def _make_lifecycle(
+    model: str,
+    provider: str = "openai",
+    replacement: str | None = "gpt-4.1",
+) -> ModelLifecycle:
+    return ModelLifecycle(
+        model=model,
+        provider=provider,
+        status="retiring",
+        shutdown_date=date(2026, 10, 1),
+        replacement=replacement,
+    )
+
+
+@pytest.fixture
+def registry_path(tmp_path: Path) -> Path:
+    return tmp_path / "registry.json"
+
+
+# --- Given steps ---
+
+
+@given(
+    parsers.cfparse("a registry with {count:d} models"),
+    target_fixture="seed_registry",
+)
+def given_registry_with_n_models(registry_path: Path, count: int) -> Path:
+    models = {f"model-{i}": _make_lifecycle(f"model-{i}") for i in range(count)}
+    save_registry(models, registry_path)
+    return registry_path
+
+
+@given(
+    parsers.cfparse('a feed returning {count:d} new model "{model}" from "{provider}"'),
+    target_fixture="mock_feed",
+)
+def given_feed_with_new_model(
+    model: str, provider: str, count: int
+) -> list[ModelLifecycle]:
+    return [_make_lifecycle(model, provider=provider.lower())]
+
+
+@given(
+    parsers.cfparse('a registry with model "{model}" replacement "{replacement}"'),
+    target_fixture="seed_registry",
+)
+def given_registry_with_specific_model(
+    registry_path: Path, model: str, replacement: str
+) -> Path:
+    models = {model: _make_lifecycle(model, replacement=replacement)}
+    save_registry(models, registry_path)
+    return registry_path
+
+
+@given(
+    parsers.cfparse('a feed returning model "{model}" with replacement "{replacement}"'),
+    target_fixture="mock_feed",
+)
+def given_feed_with_replacement(model: str, replacement: str) -> list[ModelLifecycle]:
+    return [_make_lifecycle(model, replacement=replacement)]
+
+
+@given(
+    "a feed returning no data",
+    target_fixture="mock_feed",
+)
+def given_empty_feed() -> list[ModelLifecycle]:
+    return []
+
+
+# --- When steps ---
+
+
+@when(
+    "I run the registry update",
+    target_fixture="update_result",
+)
+def run_update(
+    registry_path: Path, mock_feed: list[ModelLifecycle]
+) -> dict[str, int]:
+    with (
+        patch("src.update_registry.fetch_deprecations", return_value=mock_feed),
+        patch("src.update_registry._create_feed_failure_issue"),
+    ):
+        feed_count = update_registry(registry_path)
+    return {"feed_count": feed_count}
+
+
+# --- Then steps ---
+
+
+@then(parsers.cfparse("the registry should have {count:d} models"))
+def check_registry_count(
+    registry_path: Path, update_result: dict[str, int], count: int
+) -> None:
+    registry = load_registry(registry_path)
+    assert len(registry) == count, (
+        f"Expected {count} models, got {len(registry)}: {list(registry.keys())}"
+    )
+
+
+@then(parsers.cfparse('the registry should contain "{model}"'))
+def check_registry_contains(
+    registry_path: Path, update_result: dict[str, int], model: str
+) -> None:
+    registry = load_registry(registry_path)
+    assert model in registry, f"Expected '{model}' in registry, got {list(registry.keys())}"
+
+
+@then(parsers.cfparse('the registry entry "{model}" should have replacement "{replacement}"'))
+def check_registry_replacement(
+    registry_path: Path, update_result: dict[str, int], model: str, replacement: str
+) -> None:
+    registry = load_registry(registry_path)
+    entry = registry.get(model)
+    assert entry is not None, f"Model '{model}' not found in registry"
+    assert entry.replacement == replacement, (
+        f"Expected replacement '{replacement}', got '{entry.replacement}'"
+    )


### PR DESCRIPTION
## Summary
- Scan pipeline (`main.py`) no longer makes network calls — reads from `data/registry.json` only
- New standalone update script (`src/update_registry.py`) fetches from deprecations.info, merges, and saves
- Biweekly GitHub Actions workflow (`.github/workflows/update-registry.yml`) runs the update and commits changes
- On feed failure, creates a GitHub issue in French assigned to @Dpothier and @jsleb333
- Added `src/deprecation_feed.py` for feed fetching/parsing
- Added pre-commit config and ruff config for code quality
- 3 new BDD tests for update registry scenarios

## Test plan
- [x] All 139 tests pass (136 existing + 3 new BDD scenarios)
- [x] Ruff check + format clean
- [x] Mypy strict mode clean
- [ ] Verify workflow runs correctly via manual dispatch after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)