### PR TITLE
fix: registry workflow uses PR, README in French, bi-weekly

### DIFF
--- a/.github/workflows/update-registry.yml
+++ b/.github/workflows/update-registry.yml
@@ -39,19 +39,19 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          git diff --quiet data/registry.json && echo "Aucun changement" && exit 0
+          git diff --quiet data/registry.json README.md && echo "Aucun changement" && exit 0
 
           BRANCH="chore/update-registry-$(date +%Y-%m-%d)"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
-          git add data/registry.json
+          git add data/registry.json README.md
           git commit -m "chore: mise a jour du registre depuis deprecations.info"
           git push -u origin "$BRANCH"
 
           gh pr create \
             --title "chore: mise a jour du registre de deprecation" \
-            --body "Mise a jour automatique du registre depuis [deprecations.info](https://deprecations.info/)." \
+            --body "Mise a jour automatique du registre et du README depuis [deprecations.info](https://deprecations.info/)." \
             --head "$BRANCH" \
             --base main
 

--- a/README.md
+++ b/README.md
@@ -1,40 +1,65 @@
 # LLM Configuration Scanner
 
-GitHub Composite Action that scans repositories for LLM model references and creates issues when deprecated models are detected.
+Action composite GitHub qui scanne les dépôts pour détecter les références à des modèles LLM et crée des issues lorsque des modèles dépréciés sont détectés.
 
-## What it does
+## Ce que ça fait
 
-1. **Scans** source code and config files for LLM model references (OpenAI, Anthropic, Google)
-2. **Checks** against a JSON deprecation registry (`data/registry.json`) for deprecated/retiring/shutdown models
-3. **Creates GitHub Issues** for each deprecated model found, with affected files, replacement suggestions, and shutdown dates
-4. **Notifies Slack** (optional) when deprecated models are detected
+1. **Scanne** le code source et les fichiers de configuration pour trouver les références aux modèles LLM (OpenAI, Anthropic, Google)
+2. **Vérifie** contre un registre de dépréciation JSON (`data/registry.json`) les modèles dépréciés/en retrait/arrêtés
+3. **Crée des issues GitHub** pour chaque modèle déprécié trouvé, avec les fichiers affectés, les suggestions de remplacement et les dates d'arrêt
+4. **Notifie Slack** (optionnel) lorsque des modèles dépréciés sont détectés
 
-## Data sources
+## Sources de données
 
 | Source | Description |
 |---|---|
-| `data/registry.json` | JSON registry of deprecated models, committed in the repo |
-| [deprecations.info](https://deprecations.info/) | Live feed merged into the registry every two weeks via GitHub Actions |
-| [OpenAI deprecations](https://platform.openai.com/docs/deprecations) | Official OpenAI source |
-| [Anthropic deprecations](https://platform.claude.com/docs/en/about-claude/model-deprecations) | Official Anthropic source |
-| [Google deprecations](https://ai.google.dev/gemini-api/docs/deprecations) | Official Google source |
+| `data/registry.json` | Registre JSON des modèles dépréciés, commité dans le dépôt |
+| [deprecations.info](https://deprecations.info/) | Flux en direct fusionné dans le registre aux deux semaines via GitHub Actions |
+| [OpenAI deprecations](https://platform.openai.com/docs/deprecations) | Source officielle OpenAI |
+| [Anthropic deprecations](https://platform.claude.com/docs/en/about-claude/model-deprecations) | Source officielle Anthropic |
+| [Google deprecations](https://ai.google.dev/gemini-api/docs/deprecations) | Source officielle Google |
 
-The registry is updated every two weeks by `.github/workflows/update-registry.yml`. The scan pipeline reads from the local JSON file only — no network calls at scan time. If the feed is unreachable, a GitHub issue is automatically created.
+Le registre est mis à jour aux deux semaines par `.github/workflows/update-registry.yml`. Le pipeline de scan lit uniquement le fichier JSON local — aucun appel réseau lors du scan. Si le flux est inaccessible, une issue GitHub est automatiquement créée.
 
-## Supported models
+## Modèles supportés
 
-| Provider | Models detected |
+| Fournisseur | Modèles détectés |
 |---|---|
 | OpenAI | gpt-4.1, gpt-5, gpt-5.1, gpt-4o, gpt-4-turbo, gpt-3.5-turbo, o1/o3/o4-mini, codex-mini |
 | Anthropic | claude-opus-4, claude-sonnet-4, claude-3.5-sonnet/haiku, claude-3-opus/sonnet/haiku |
 | Google | gemini-2.5-pro/flash, gemini-2.0-flash, gemini-1.5-pro/flash, gemini-pro |
 | Embeddings | text-embedding-3-small/large, text-embedding-ada-002, voyage-* |
 
-## Usage
+## Modèles dépréciés suivis
 
-### 1. Add the workflow to your repository
+<!-- REGISTRY_START -->
+| Model | Provider | Status | Shutdown date | Replacement |
+|---|---|---|---|---|
+| claude-3-opus | anthropic | shutdown | 2026-01-05 | claude-opus-4 |
+| claude-3-sonnet | anthropic | shutdown | 2025-07-21 | claude-sonnet-4 |
+| claude-3.5-haiku | anthropic | deprecated | 2026-02-19 | claude-haiku-4-5 |
+| claude-3.5-sonnet | anthropic | shutdown | 2025-10-28 | claude-sonnet-4 |
+| gemini-1.5-flash | google | shutdown | 2025-09-23 | gemini-2.5-flash |
+| gemini-1.5-pro | google | shutdown | 2025-09-23 | gemini-2.5-pro |
+| gemini-2.0-flash | google | retiring | 2026-03-31 | gemini-2.5-flash |
+| gemini-pro | google | shutdown | 2025-02-15 | gemini-2.5-pro |
+| gpt-3.5-turbo | openai | deprecated | 2025-09-14 | gpt-4.1-mini |
+| gpt-4 | openai | retiring | 2026-06-06 | gpt-4.1 |
+| gpt-4-turbo | openai | retiring | 2026-06-06 | gpt-4.1 |
+| gpt-4-turbo-preview | openai | retiring | 2026-06-06 | gpt-4.1 |
+| gpt-4o | openai | retiring | 2026-10-01 | gpt-4.1 |
+| gpt-4o-mini | openai | retiring | 2026-10-01 | gpt-4.1-mini |
+| o1 | openai | retiring | 2026-07-15 | o3 |
+| o1-mini | openai | shutdown | 2025-10-27 | o4-mini |
+| o1-preview | openai | shutdown | 2025-07-28 | o3 |
+| text-embedding-ada-002 | openai | retiring | 2027-04-15 | text-embedding-3-small |
+<!-- REGISTRY_END -->
 
-Copy `template-workflow.yml` to `.github/workflows/llm-scan.yml` in your target repository:
+## Utilisation
+
+### 1. Ajouter le workflow à votre dépôt
+
+Copiez `template-workflow.yml` dans `.github/workflows/llm-scan.yml` de votre dépôt cible :
 
 ```yaml
 name: LLM Configuration Scan
@@ -43,7 +68,7 @@ on:
   push:
     branches: [main]
   schedule:
-    - cron: "0 8 * * 1"  # Weekly on Monday
+    - cron: "0 8 1,15 * *"  # Bi-weekly: 1st and 15th of each month
   workflow_dispatch:
 
 jobs:
@@ -60,35 +85,35 @@ jobs:
           assignees: ${{ vars.LLM_SCAN_ASSIGNEES || '' }}
 ```
 
-### 2. Configure organization secrets/variables
+### 2. Configurer les secrets/variables de l'organisation
 
-| Name | Type | Description |
+| Nom | Type | Description |
 |---|---|---|
-| `LLM_SCAN_SLACK_WEBHOOK` | Secret | Slack incoming webhook URL (optional) |
-| `LLM_SCAN_ASSIGNEES` | Variable | Comma-separated GitHub usernames |
+| `LLM_SCAN_SLACK_WEBHOOK` | Secret | URL du webhook Slack entrant (optionnel) |
+| `LLM_SCAN_ASSIGNEES` | Variable | Noms d'utilisateur GitHub séparés par des virgules |
 
-## Action inputs/outputs
+## Entrées/sorties de l'action
 
-### Inputs
+### Entrées
 
-| Input | Required | Default | Description |
+| Entrée | Requis | Défaut | Description |
 |---|---|---|---|
-| `repo-name` | Yes | | Repository name |
-| `assignees` | No | `""` | Comma-separated assignees for issues |
-| `dry-run` | No | `false` | Scan only, don't create issues |
+| `repo-name` | Oui | | Nom du dépôt |
+| `assignees` | Non | `""` | Assignés séparés par des virgules |
+| `dry-run` | Non | `false` | Scanner seulement, ne pas créer d'issues |
 
-### Outputs
+### Sorties
 
-| Output | Description |
+| Sortie | Description |
 |---|---|
-| `match-count` | Total model references found |
-| `deprecated-count` | Number of deprecated model references |
-| `issues-created` | Number of GitHub issues created |
-| `deprecated-summary` | JSON summary of deprecated models |
+| `match-count` | Nombre total de références trouvées |
+| `deprecated-count` | Nombre de références à des modèles dépréciés |
+| `issues-created` | Nombre d'issues GitHub créées |
+| `deprecated-summary` | Résumé JSON des modèles dépréciés |
 
-## Registry update
+## Mise à jour du registre
 
-The registry is updated automatically every two weeks (lundi a 06:00 UTC). You can also trigger it manually:
+Le registre est mis à jour automatiquement aux deux semaines (lundi à 06:00 UTC). Vous pouvez aussi le déclencher manuellement :
 
 ```bash
 # Manually update the registry
@@ -98,9 +123,9 @@ PYTHONPATH=. python -m src.update_registry
 PYTHONPATH=. python -m src.update_registry --registry-path data/registry.json
 ```
 
-If the feed is unreachable, a GitHub issue is created with details in French, assigned to the maintainers.
+Si le flux est inaccessible, une issue GitHub est créée avec les détails en français, assignée aux mainteneurs.
 
-## Local usage
+## Utilisation locale
 
 ```bash
 PYTHONPATH=. python -m src.main --repo-name "my-repo" --scan-path /path/to/repo --dry-run
@@ -113,13 +138,13 @@ pip install pytest pytest-bdd
 python -m pytest tests/ -v --rootdir=.
 ```
 
-BDD tests covering:
-- Pattern detection (LLM models, embeddings, date suffixes, false positives)
-- Scanner (directory traversal, deduplication, exclusions)
-- Deprecation registry (deprecated vs active models, date suffix handling, coherence checks)
-- Registry update (add new models, overwrite existing, empty feed handling)
-- Issue reporter (title/body formatting, grouping, dry-run, assignee validation)
-- CLI orchestration (argument parsing, end-to-end pipelines)
+Tests BDD couvrant :
+- Détection de patterns (modèles LLM, embeddings, suffixes de date, faux positifs)
+- Scanner (parcours de répertoires, déduplication, exclusions)
+- Registre de dépréciation (modèles dépréciés vs actifs, gestion des suffixes de date, vérifications de cohérence)
+- Mise à jour du registre (ajout de nouveaux modèles, écrasement d'existants, gestion de flux vide)
+- Rapporteur d'issues (formatage titre/corps, regroupement, dry-run, validation des assignés)
+- Orchestration CLI (parsing d'arguments, pipelines bout-en-bout)
 
 ## Architecture
 

--- a/src/update_registry.py
+++ b/src/update_registry.py
@@ -8,12 +8,14 @@ from __future__ import annotations
 
 import argparse
 import logging
+import re
 import subprocess
 from pathlib import Path
 
 from src.deprecation_feed import fetch_deprecations
 from src.deprecations import (
     _DEFAULT_REGISTRY_PATH,
+    ModelLifecycle,
     load_registry,
     merge_registries,
     save_registry,
@@ -87,6 +89,61 @@ def _create_feed_failure_issue(error_detail: str) -> None:
         logger.warning("Erreur lors de la creation de l'issue : %s", exc)
 
 
+_README_MARKER_START = "<!-- REGISTRY_START -->"
+_README_MARKER_END = "<!-- REGISTRY_END -->"
+
+
+def _generate_registry_table(registry: dict[str, ModelLifecycle]) -> str:
+    """Genere le tableau Markdown des modeles deprecies pour le README."""
+    sorted_entries = sorted(registry.values(), key=lambda lc: (lc.provider, lc.model))
+    lines = [
+        "| Model | Provider | Status | Shutdown date | Replacement |",
+        "|---|---|---|---|---|",
+    ]
+    for lc in sorted_entries:
+        shutdown = lc.shutdown_date.isoformat() if lc.shutdown_date else ""
+        replacement = lc.replacement or ""
+        lines.append(f"| {lc.model} | {lc.provider} | {lc.status} | {shutdown} | {replacement} |")
+    return "\n".join(lines)
+
+
+def update_readme(registry: dict[str, ModelLifecycle], readme_path: Path) -> bool:
+    """Met a jour la section auto-generee du README avec le registre actuel.
+
+    Args:
+        registry: Le registre de deprecation.
+        readme_path: Chemin vers le fichier README.md.
+
+    Returns:
+        True si le README a ete modifie, False sinon.
+    """
+    try:
+        content = readme_path.read_text(encoding="utf-8")
+    except OSError:
+        logger.warning("Impossible de lire %s", readme_path)
+        return False
+
+    table = _generate_registry_table(registry)
+    new_section = f"{_README_MARKER_START}\n{table}\n{_README_MARKER_END}"
+
+    pattern = re.compile(
+        rf"{re.escape(_README_MARKER_START)}.*?{re.escape(_README_MARKER_END)}",
+        re.DOTALL,
+    )
+
+    if not pattern.search(content):
+        logger.warning("Marqueurs README introuvables dans %s", readme_path)
+        return False
+
+    new_content = pattern.sub(new_section, content)
+    if new_content == content:
+        return False
+
+    readme_path.write_text(new_content, encoding="utf-8")
+    logger.info("README mis a jour dans %s", readme_path)
+    return True
+
+
 def update_registry(registry_path: Path) -> int:
     """Recupere le flux, fusionne avec le registre existant et sauvegarde.
 
@@ -117,6 +174,10 @@ def update_registry(registry_path: Path) -> int:
 
     save_registry(merged, registry_path)
     logger.info("Registre sauvegarde dans %s", registry_path)
+
+    readme_path = registry_path.parent.parent / "README.md"
+    update_readme(merged, readme_path)
+
     return len(feed)
 
 

--- a/template-workflow.yml
+++ b/template-workflow.yml
@@ -18,7 +18,7 @@ on:
       - "**/*.env"
       - "**/Dockerfile"
   schedule:
-    - cron: "0 8 * * 1"  # Every Monday at 8:00 UTC
+    - cron: "0 8 1,15 * *"  # Bi-weekly: 1st and 15th of each month at 8:00 UTC
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary
- Registry update workflow now creates a PR (with auto-merge) instead of pushing directly to protected `main`
- README rewritten in French (code snippets remain in English)
- Added `update_readme()` to auto-generate the deprecated models table in the README
- Template and README scan schedule changed to bi-weekly (1st and 15th of each month)

## Changes
- `.github/workflows/update-registry.yml`: PR-based flow, stages README.md
- `src/update_registry.py`: `update_readme()` + `_generate_registry_table()`
- `README.md`: Full French translation with auto-generated registry table
- `template-workflow.yml`: Bi-weekly cron schedule

## Test plan
- [ ] All 139 existing BDD tests pass
- [ ] `update_readme()` correctly replaces content between markers
- [ ] Workflow creates PR instead of pushing directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)