### PR TITLE
feat: one-pager, regex validation, future model tests, Claude CI

### DIFF
--- a/.github/workflows/update-registry.yml
+++ b/.github/workflows/update-registry.yml
@@ -9,6 +9,7 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  id-token: write
 
 jobs:
   update:
@@ -36,6 +37,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Creer une PR si le registre a change
+        id: create-pr
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -55,4 +57,28 @@ jobs:
             --head "$BRANCH" \
             --base main
 
+          PR_URL=$(gh pr view "$BRANCH" --json url -q .url)
+          echo "pr-url=$PR_URL" >> "$GITHUB_OUTPUT"
+
           gh pr merge "$BRANCH" --squash --auto --delete-branch
+
+      - name: Valider la couverture regex avec Claude
+        if: steps.create-pr.outputs.pr-url != ''
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            Analyse les modeles dans data/registry.json.
+            Pour chaque modele, verifie si les patterns regex dans src/patterns.py
+            peuvent le detecter en executant :
+
+              PYTHONPATH=. python -m src.validate_patterns --output-json
+
+            Si des lacunes sont trouvees :
+            1. Liste les modeles non couverts
+            2. Suggere des patterns regex a ajouter dans src/patterns.py
+            3. Suggere des cas de test BDD a ajouter dans tests/features/patterns.feature
+
+            Poste un commentaire sur la PR avec les resultats.
+          claude_args: |
+            --allowedTools "Bash(python:*),Bash(gh pr comment:*),Read,Glob,Grep"

--- a/docs/one-pager.md
+++ b/docs/one-pager.md
@@ -1,0 +1,63 @@
+# LLM Configuration Scanner - One-Pager
+
+## Besoin metier
+
+Les projets de Baseline utilisent des modeles LLM (OpenAI, Anthropic, Google) qui sont regulierement deprecies par leurs fournisseurs. Un modele retire sans migration prealable provoque des **pannes en production**. Il faut detecter proactivement les references a des modeles deprecies dans l'ensemble des depots de code.
+
+## Exigences fonctionnelles
+
+| # | Exigence | Statut |
+|---|----------|--------|
+| F1 | Scanner les fichiers source (.py, .yml, .json, .ts, etc.) pour detecter les references aux modeles LLM | Implemente |
+| F2 | Detecter les modeles de 3 fournisseurs (OpenAI, Anthropic, Google) et les embeddings (OpenAI, Voyage) | Implemente |
+| F3 | Comparer les modeles detectes au registre de depreciation JSON (`data/registry.json`) | Implemente |
+| F4 | Gerer les suffixes de date (ex: `gpt-4o-2024-08-06` -> `gpt-4o`) | Implemente |
+| F5 | Creer automatiquement des issues GitHub avec fichiers affectes et remplacement suggere | Implemente |
+| F6 | Eviter les doublons d'issues (verification avant creation) | Implemente |
+| F7 | Alimenter le registre depuis le flux live deprecations.info | Implemente |
+| F8 | Mettre a jour le registre automatiquement toutes les 2 semaines via PR | Implemente |
+| F9 | Creer une issue GitHub automatiquement si le flux est inaccessible | Implemente |
+| F10 | Valider la couverture regex des nouveaux modeles via Claude lors des mises a jour du registre | Implemente |
+
+## Exigences techniques
+
+| # | Exigence | Statut |
+|---|----------|--------|
+| T1 | GitHub Composite Action reutilisable par tous les depots | Implemente |
+| T2 | Registre JSON persiste (`data/registry.json`) avec date de mise a jour | Implemente |
+| T3 | Workflow de mise a jour bimensuel (`update-registry.yml`) avec PR automatique et auto-merge | Implemente |
+| T4 | Tests BDD couvrant : patterns, scanner, depreciations, feed, issues, CLI, registre | Implemente |
+| T5 | CI : lint (ruff), tests (pytest), type checking (mypy) | Implemente |
+| T6 | Zero dependance runtime (stdlib Python + gh CLI uniquement) | Implemente |
+| T7 | Script de validation regex (`src/validate_patterns.py`) pour verifier la couverture des patterns | Implemente |
+| T8 | Integration Claude (`claude-code-action`) pour revue automatique des lacunes regex | Implemente |
+
+## Architecture
+
+```
+data/
+  registry.json          # Registre JSON des modeles deprecies
+docs/
+  one-pager.md           # Ce document
+src/
+  patterns.py            # Patterns regex pour la detection de modeles
+  scanner.py             # Parcours de repertoire et scan de fichiers
+  models.py              # Modeles de donnees (ScanMatch, ScanResult)
+  deprecations.py        # Chargement du registre + gestion des suffixes de date
+  deprecation_feed.py    # Flux live depuis deprecations.info
+  update_registry.py     # Script : fetch -> merge -> save (+ issue en cas d'echec)
+  validate_patterns.py   # Validation de couverture regex pour les modeles du registre
+  issue_reporter.py      # Creation d'issues GitHub via gh CLI
+  main.py                # Point d'entree CLI et orchestration du scan
+.github/workflows/
+  ci.yml                 # CI : lint, tests, type checking
+  update-registry.yml    # Cron bimensuel : mise a jour registre + validation Claude
+```
+
+## Flux de donnees
+
+1. **Scan** : `scanner.py` parcourt un depot cible, `patterns.py` detecte les modeles
+2. **Verification** : chaque modele trouve est compare au registre JSON local
+3. **Alerte** : `issue_reporter.py` cree des issues GitHub pour les modeles deprecies
+4. **Mise a jour** : `update_registry.py` recupere le flux deprecations.info et met a jour `registry.json`
+5. **Validation** : Claude verifie que les patterns regex couvrent les nouveaux modeles du registre

--- a/src/validate_patterns.py
+++ b/src/validate_patterns.py
@@ -1,0 +1,92 @@
+"""Validate that all models in the registry are matched by regex patterns.
+
+Usage:
+    PYTHONPATH=. python -m src.validate_patterns [--registry-path data/registry.json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+
+from src.deprecations import _DEFAULT_REGISTRY_PATH, load_registry
+from src.patterns import find_matches_in_line
+
+
+logger = logging.getLogger(__name__)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Validate regex pattern coverage for registry models",
+    )
+    parser.add_argument(
+        "--registry-path",
+        type=Path,
+        default=_DEFAULT_REGISTRY_PATH,
+        help="Path to the registry JSON file (default: data/registry.json)",
+    )
+    parser.add_argument(
+        "--output-json",
+        action="store_true",
+        help="Output results as JSON instead of human-readable text",
+    )
+    return parser.parse_args(argv)
+
+
+def validate_coverage(registry_path: Path) -> dict[str, list[str]]:
+    """Check which registry models are matched by existing patterns.
+
+    Args:
+        registry_path: Path to the registry JSON file.
+
+    Returns:
+        Dict with 'matched' and 'unmatched' lists of model names.
+    """
+    registry = load_registry(registry_path)
+    matched: list[str] = []
+    unmatched: list[str] = []
+
+    for model_name in registry:
+        line = f'model = "{model_name}"'
+        matches = find_matches_in_line(line)
+        matched_models = [m[1] for m in matches]
+        if model_name in matched_models:
+            matched.append(model_name)
+        else:
+            unmatched.append(model_name)
+
+    return {"matched": matched, "unmatched": unmatched}
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Entry point for the validation script."""
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    args = parse_args(argv)
+
+    results = validate_coverage(args.registry_path)
+
+    if args.output_json:
+        print(json.dumps(results, indent=2))
+    else:
+        logger.info("Matched: %d models", len(results["matched"]))
+        for model in results["matched"]:
+            logger.info("  + %s", model)
+
+        if results["unmatched"]:
+            logger.warning("Unmatched: %d models", len(results["unmatched"]))
+            for model in results["unmatched"]:
+                logger.warning("  - %s", model)
+        else:
+            logger.info("All registry models are covered by patterns.")
+
+    if results["unmatched"]:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/features/patterns.feature
+++ b/tests/features/patterns.feature
@@ -151,3 +151,22 @@ Feature: LLM model pattern detection
     Given a line containing "Hello world, this is a normal line of code"
     When I scan the line for matches
     Then I should find 0 matches
+
+  Scenario Outline: Detect plausible future model names
+    Given a line containing "<line>"
+    When I scan the line for matches
+    Then I should find model "<model>" from provider "<provider>"
+    And the match type should be "llm"
+
+    Examples:
+      | line                             | model              | provider  |
+      | model = "gpt-5-pro"             | gpt-5-pro          | openai    |
+      | model = "gpt-5-codex"           | gpt-5-codex        | openai    |
+      | model: gpt-5-chat               | gpt-5-chat         | openai    |
+      | model = "gpt-5.1-mini"          | gpt-5.1-mini       | openai    |
+      | model = "gpt-5.2-nano"          | gpt-5.2-nano       | openai    |
+      | model = "gpt-4.1-2025-06-01"    | gpt-4.1-2025-06-01 | openai    |
+      | model = "gemini-2.5-pro-001"    | gemini-2.5-pro-001 | google    |
+      | model = "gemini-2.5-flash-002"  | gemini-2.5-flash-002 | google  |
+      | model: claude-3-5-haiku-20250601 | claude-3-5-haiku-20250601 | anthropic |
+      | model = "claude-3.5-sonnet-20260101" | claude-3.5-sonnet-20260101 | anthropic |


### PR DESCRIPTION
## Summary
- Add `docs/one-pager.md` with business/technical requirements in French
- Add `src/validate_patterns.py` to check registry model coverage against regex patterns
- Add 10 future model name BDD test cases (GPT-5 variants, Gemini, Claude)
- Add Claude validation step (`claude-code-action@v1`) in update-registry workflow

## Test plan
- [x] 149 tests pass (`python -m pytest tests/ -v`)
- [x] Ruff lint + format clean
- [x] `validate_patterns.py` confirms 18/18 registry models matched
- [x] Workflow YAML is valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)