### PR TITLE
refactor: simplifier le modèle de données et le workflow

### DIFF
--- a/.github/workflows/update-registry.yml
+++ b/.github/workflows/update-registry.yml
@@ -35,15 +35,31 @@ jobs:
         env:
           PYTHONPATH: ${{ github.workspace }}
           GH_TOKEN: ${{ github.token }}
-          REGISTRY_ASSIGNEES: ${{ vars.REGISTRY_ASSIGNEES || '' }}
+          LLM_SCAN_ASSIGNEES: ${{ vars.LLM_SCAN_ASSIGNEES || '' }}
 
-      - name: Creer une PR si le registre a change
+      - name: Detecter les changements du registre
+        id: detect-changes
+        run: |
+          if git diff --quiet data/registry.json; then
+            echo "Aucun changement dans le registre"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Changements detectes dans le registre"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Mettre a jour le README
+        if: steps.detect-changes.outputs.changed == 'true'
+        run: python -c "from src.update_registry import update_readme; from src.deprecations import load_registry; from pathlib import Path; update_readme(load_registry(), Path('README.md'))"
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+
+      - name: Creer une PR
         id: create-pr
+        if: steps.detect-changes.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          git diff --quiet data/registry.json README.md && echo "Aucun changement" && exit 0
-
           BRANCH="chore/update-registry-$(date +%Y-%m-%d)"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Action composite GitHub qui scanne les dépôts pour détecter les références 
 
 1. **Scanne** le code source et les fichiers de configuration pour trouver les références aux modèles LLM (OpenAI, Anthropic, Google)
 2. **Vérifie** contre un registre de dépréciation JSON (`data/registry.json`) les modèles dépréciés/en retrait/arrêtés
-3. **Crée des issues GitHub** pour chaque modèle déprécié trouvé, avec les fichiers affectés, les suggestions de remplacement et les dates d'arrêt
+3. **Crée des issues GitHub** pour chaque modèle déprécié trouvé, avec les fichiers affectés et les dates d'arrêt
 
 ### Workflow de scan (repos consommateurs)
 
@@ -16,7 +16,7 @@ flowchart LR
     B --> C[Action composite<br>tracking-llm-discontinued]
     C --> D[Scan des fichiers<br>patterns.py + scanner.py]
     D --> E{Modèles<br>dépréciés?}
-    E -->|Oui| F[Créer issues GitHub<br>avec remplacement suggéré]
+    E -->|Oui| F[Créer issues GitHub<br>avec date d'arrêt]
     E -->|Non| G[Aucune action]
 ```
 
@@ -28,10 +28,10 @@ flowchart TD
     B --> C{Flux<br>accessible?}
     C -->|Non| D[Créer issue<br>d'échec]
     C -->|Oui| E[Fusionner avec<br>registry.json]
-    E --> F[Mettre à jour<br>le README]
-    F --> G{Changements<br>détectés?}
-    G -->|Non| H[Fin]
-    G -->|Oui| I[Créer PR]
+    E --> F{Changements<br>détectés?}
+    F -->|Non| G[Fin]
+    F -->|Oui| H[Mettre à jour<br>le README]
+    H --> I[Créer PR]
     I --> J[Claude Code valide<br>et ajuste les regex]
     J --> K[Auto-merge PR]
 ```
@@ -48,26 +48,26 @@ flowchart TD
 ## Modèles dépréciés suivis
 
 <!-- REGISTRY_START -->
-| Model | Provider | Status | Shutdown date | Replacement |
-|---|---|---|---|---|
-| claude-3-opus | anthropic | shutdown | 2026-01-05 | claude-opus-4 |
-| claude-3-sonnet | anthropic | shutdown | 2025-07-21 | claude-sonnet-4 |
-| claude-3.5-haiku | anthropic | deprecated | 2026-02-19 | claude-haiku-4-5 |
-| claude-3.5-sonnet | anthropic | shutdown | 2025-10-28 | claude-sonnet-4 |
-| gemini-1.5-flash | google | shutdown | 2025-09-23 | gemini-2.5-flash |
-| gemini-1.5-pro | google | shutdown | 2025-09-23 | gemini-2.5-pro |
-| gemini-2.0-flash | google | retiring | 2026-03-31 | gemini-2.5-flash |
-| gemini-pro | google | shutdown | 2025-02-15 | gemini-2.5-pro |
-| gpt-3.5-turbo | openai | deprecated | 2025-09-14 | gpt-4.1-mini |
-| gpt-4 | openai | retiring | 2026-06-06 | gpt-4.1 |
-| gpt-4-turbo | openai | retiring | 2026-06-06 | gpt-4.1 |
-| gpt-4-turbo-preview | openai | retiring | 2026-06-06 | gpt-4.1 |
-| gpt-4o | openai | retiring | 2026-10-01 | gpt-4.1 |
-| gpt-4o-mini | openai | retiring | 2026-10-01 | gpt-4.1-mini |
-| o1 | openai | retiring | 2026-07-15 | o3 |
-| o1-mini | openai | shutdown | 2025-10-27 | o4-mini |
-| o1-preview | openai | shutdown | 2025-07-28 | o3 |
-| text-embedding-ada-002 | openai | retiring | 2027-04-15 | text-embedding-3-small |
+| Model | Provider | Status | Shutdown date |
+|---|---|---|---|
+| claude-3-opus | anthropic | shutdown | 2026-01-05 |
+| claude-3-sonnet | anthropic | shutdown | 2025-07-21 |
+| claude-3.5-haiku | anthropic | deprecated | 2026-02-19 |
+| claude-3.5-sonnet | anthropic | shutdown | 2025-10-28 |
+| gemini-1.5-flash | google | shutdown | 2025-09-23 |
+| gemini-1.5-pro | google | shutdown | 2025-09-23 |
+| gemini-2.0-flash | google | retiring | 2026-03-31 |
+| gemini-pro | google | shutdown | 2025-02-15 |
+| gpt-3.5-turbo | openai | deprecated | 2025-09-14 |
+| gpt-4 | openai | retiring | 2026-06-06 |
+| gpt-4-turbo | openai | retiring | 2026-06-06 |
+| gpt-4-turbo-preview | openai | retiring | 2026-06-06 |
+| gpt-4o | openai | retiring | 2026-10-01 |
+| gpt-4o-mini | openai | retiring | 2026-10-01 |
+| o1 | openai | retiring | 2026-07-15 |
+| o1-mini | openai | shutdown | 2025-10-27 |
+| o1-preview | openai | shutdown | 2025-07-28 |
+| text-embedding-ada-002 | openai | retiring | 2027-04-15 |
 <!-- REGISTRY_END -->
 
 ---
@@ -147,8 +147,8 @@ Le pipeline de scan lit uniquement le fichier JSON local — aucun appel réseau
 Le registre est mis à jour automatiquement aux deux semaines (lundi à 06:00 UTC) par `.github/workflows/update-registry.yml`. Le workflow :
 
 1. Récupère le flux depuis [deprecations.info](https://deprecations.info/)
-2. Fusionne avec le registre existant et met à jour le README
-3. Crée une PR avec les changements
+2. Fusionne avec le registre existant
+3. Si des changements sont détectés : met à jour le README et crée une PR
 4. Claude Code valide et ajuste les patterns regex si nécessaire
 5. La PR est auto-mergée
 
@@ -165,7 +165,7 @@ PYTHONPATH=. python -m src.update_registry
 | Nom | Type | Description |
 |---|---|---|
 | `ANTHROPIC_API_KEY` | Repository secret | Clé API Anthropic pour la validation Claude dans le workflow de mise à jour |
-| `REGISTRY_ASSIGNEES` | Repository variable | Noms d'utilisateur GitHub assignés aux issues d'échec du flux (séparés par des virgules) |
+| `LLM_SCAN_ASSIGNEES` | Organization variable | Noms d'utilisateur GitHub assignés aux issues (partagée avec les repos consommateurs) |
 
 ### Utilisation locale
 

--- a/data/registry.json
+++ b/data/registry.json
@@ -5,145 +5,109 @@
       "model": "claude-3-opus",
       "provider": "anthropic",
       "status": "shutdown",
-      "shutdown_date": "2026-01-05",
-      "replacement": "claude-opus-4",
-      "note": ""
+      "shutdown_date": "2026-01-05"
     },
     {
       "model": "claude-3-sonnet",
       "provider": "anthropic",
       "status": "shutdown",
-      "shutdown_date": "2025-07-21",
-      "replacement": "claude-sonnet-4",
-      "note": ""
+      "shutdown_date": "2025-07-21"
     },
     {
       "model": "claude-3.5-haiku",
       "provider": "anthropic",
       "status": "deprecated",
-      "shutdown_date": "2026-02-19",
-      "replacement": "claude-haiku-4-5",
-      "note": ""
+      "shutdown_date": "2026-02-19"
     },
     {
       "model": "claude-3.5-sonnet",
       "provider": "anthropic",
       "status": "shutdown",
-      "shutdown_date": "2025-10-28",
-      "replacement": "claude-sonnet-4",
-      "note": "Both v1 (20240620) and v2 (20241022) retired"
+      "shutdown_date": "2025-10-28"
     },
     {
       "model": "gemini-1.5-flash",
       "provider": "google",
       "status": "shutdown",
-      "shutdown_date": "2025-09-23",
-      "replacement": "gemini-2.5-flash",
-      "note": "gemini-1.5-flash-001/002 retired"
+      "shutdown_date": "2025-09-23"
     },
     {
       "model": "gemini-1.5-pro",
       "provider": "google",
       "status": "shutdown",
-      "shutdown_date": "2025-09-23",
-      "replacement": "gemini-2.5-pro",
-      "note": "gemini-1.5-pro-001/002 retired"
+      "shutdown_date": "2025-09-23"
     },
     {
       "model": "gemini-2.0-flash",
       "provider": "google",
       "status": "retiring",
-      "shutdown_date": "2026-03-31",
-      "replacement": "gemini-2.5-flash",
-      "note": ""
+      "shutdown_date": "2026-03-31"
     },
     {
       "model": "gemini-pro",
       "provider": "google",
       "status": "shutdown",
-      "shutdown_date": "2025-02-15",
-      "replacement": "gemini-2.5-pro",
-      "note": "Original Gemini 1.0 Pro, retired"
+      "shutdown_date": "2025-02-15"
     },
     {
       "model": "gpt-3.5-turbo",
       "provider": "openai",
       "status": "deprecated",
-      "shutdown_date": "2025-09-14",
-      "replacement": "gpt-4.1-mini",
-      "note": "All gpt-3.5-turbo variants included"
+      "shutdown_date": "2025-09-14"
     },
     {
       "model": "gpt-4",
       "provider": "openai",
       "status": "retiring",
-      "shutdown_date": "2026-06-06",
-      "replacement": "gpt-4.1",
-      "note": ""
+      "shutdown_date": "2026-06-06"
     },
     {
       "model": "gpt-4-turbo",
       "provider": "openai",
       "status": "retiring",
-      "shutdown_date": "2026-06-06",
-      "replacement": "gpt-4.1",
-      "note": ""
+      "shutdown_date": "2026-06-06"
     },
     {
       "model": "gpt-4-turbo-preview",
       "provider": "openai",
       "status": "retiring",
-      "shutdown_date": "2026-06-06",
-      "replacement": "gpt-4.1",
-      "note": ""
+      "shutdown_date": "2026-06-06"
     },
     {
       "model": "gpt-4o",
       "provider": "openai",
       "status": "retiring",
-      "shutdown_date": "2026-10-01",
-      "replacement": "gpt-4.1",
-      "note": "Standard deployments retire 2026-03-31"
+      "shutdown_date": "2026-10-01"
     },
     {
       "model": "gpt-4o-mini",
       "provider": "openai",
       "status": "retiring",
-      "shutdown_date": "2026-10-01",
-      "replacement": "gpt-4.1-mini",
-      "note": "Standard deployments retire 2026-03-31"
+      "shutdown_date": "2026-10-01"
     },
     {
       "model": "o1",
       "provider": "openai",
       "status": "retiring",
-      "shutdown_date": "2026-07-15",
-      "replacement": "o3",
-      "note": ""
+      "shutdown_date": "2026-07-15"
     },
     {
       "model": "o1-mini",
       "provider": "openai",
       "status": "shutdown",
-      "shutdown_date": "2025-10-27",
-      "replacement": "o4-mini",
-      "note": ""
+      "shutdown_date": "2025-10-27"
     },
     {
       "model": "o1-preview",
       "provider": "openai",
       "status": "shutdown",
-      "shutdown_date": "2025-07-28",
-      "replacement": "o3",
-      "note": ""
+      "shutdown_date": "2025-07-28"
     },
     {
       "model": "text-embedding-ada-002",
       "provider": "openai",
       "status": "retiring",
-      "shutdown_date": "2027-04-15",
-      "replacement": "text-embedding-3-small",
-      "note": "No retirement before April 2027"
+      "shutdown_date": "2027-04-15"
     }
   ]
 }

--- a/src/deprecation_feed.py
+++ b/src/deprecation_feed.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Any
 
 
 if TYPE_CHECKING:
-    from src.deprecations import DeprecationStatus, ModelLifecycle
+    from src.deprecations import DeprecatedModel, DeprecationStatus
 
 logger = logging.getLogger(__name__)
 
@@ -28,10 +28,10 @@ PROVIDER_MAP: dict[str, str] = {
 }
 
 
-def fetch_deprecations() -> list[ModelLifecycle]:
+def fetch_deprecations() -> list[DeprecatedModel]:
     """Fetch deprecation data from deprecations.info.
 
-    Returns a list of ModelLifecycle objects for tracked providers.
+    Returns a list of DeprecatedModel objects for tracked providers.
     Returns an empty list on any network or parsing error (silent fallback).
     """
     try:
@@ -45,11 +45,11 @@ def fetch_deprecations() -> list[ModelLifecycle]:
     return _parse_feed(data)
 
 
-def _parse_feed(data: list[dict[str, Any]]) -> list[ModelLifecycle]:
-    """Parse raw JSON entries into ModelLifecycle objects."""
-    from src.deprecations import ModelLifecycle
+def _parse_feed(data: list[dict[str, Any]]) -> list[DeprecatedModel]:
+    """Parse raw JSON entries into DeprecatedModel objects."""
+    from src.deprecations import DeprecatedModel
 
-    results: list[ModelLifecycle] = []
+    results: list[DeprecatedModel] = []
     for entry in data:
         provider_raw = entry.get("provider", "")
         internal_provider = PROVIDER_MAP.get(provider_raw)
@@ -61,8 +61,6 @@ def _parse_feed(data: list[dict[str, Any]]) -> list[ModelLifecycle]:
             continue
 
         shutdown_date = _parse_date(entry.get("shutdown_date"))
-        replacement_models = entry.get("replacement_models")
-        replacement = replacement_models[0] if replacement_models else None
 
         # Determine status from dates
         status: DeprecationStatus
@@ -75,12 +73,11 @@ def _parse_feed(data: list[dict[str, Any]]) -> list[ModelLifecycle]:
             status = "deprecated"
 
         results.append(
-            ModelLifecycle(
+            DeprecatedModel(
                 model=model_id,
                 provider=internal_provider,
                 status=status,
                 shutdown_date=shutdown_date,
-                replacement=replacement,
             )
         )
 

--- a/src/deprecations.py
+++ b/src/deprecations.py
@@ -25,50 +25,44 @@ _DATE_SUFFIX_RE = re.compile(r"-\d{4}-?\d{2}-?\d{2}$")
 
 
 @dataclass(frozen=True)
-class ModelLifecycle:
-    """Lifecycle information for a deprecated or retiring model."""
+class DeprecatedModel:
+    """Information about a deprecated or retiring model."""
 
     model: str
     provider: str
     status: DeprecationStatus
     shutdown_date: date | None = None
-    replacement: str | None = None
-    note: str = ""
 
 
-def _entry_to_lifecycle(entry: dict[str, Any]) -> ModelLifecycle:
-    """Convert a JSON entry to a ModelLifecycle object."""
+def _entry_to_deprecated(entry: dict[str, Any]) -> DeprecatedModel:
+    """Convert a JSON entry to a DeprecatedModel object."""
     shutdown_str = entry.get("shutdown_date")
-    return ModelLifecycle(
+    return DeprecatedModel(
         model=entry["model"],
         provider=entry["provider"],
         status=entry["status"],
         shutdown_date=date.fromisoformat(shutdown_str) if shutdown_str else None,
-        replacement=entry.get("replacement"),
-        note=entry.get("note", ""),
     )
 
 
-def _lifecycle_to_dict(lc: ModelLifecycle) -> dict[str, Any]:
-    """Convert a ModelLifecycle object to a JSON-serializable dict."""
+def _deprecated_to_dict(dm: DeprecatedModel) -> dict[str, Any]:
+    """Convert a DeprecatedModel object to a JSON-serializable dict."""
     return {
-        "model": lc.model,
-        "provider": lc.provider,
-        "status": lc.status,
-        "shutdown_date": lc.shutdown_date.isoformat() if lc.shutdown_date else None,
-        "replacement": lc.replacement,
-        "note": lc.note,
+        "model": dm.model,
+        "provider": dm.provider,
+        "status": dm.status,
+        "shutdown_date": dm.shutdown_date.isoformat() if dm.shutdown_date else None,
     }
 
 
-def load_registry(path: Path | None = None) -> dict[str, ModelLifecycle]:
+def load_registry(path: Path | None = None) -> dict[str, DeprecatedModel]:
     """Load registry from JSON file.
 
     Args:
         path: Path to the registry JSON file. Defaults to data/registry.json.
 
     Returns:
-        Dictionary mapping model names to ModelLifecycle objects.
+        Dictionary mapping model names to DeprecatedModel objects.
     """
     registry_path = path or _DEFAULT_REGISTRY_PATH
     try:
@@ -76,35 +70,35 @@ def load_registry(path: Path | None = None) -> dict[str, ModelLifecycle]:
     except (OSError, json.JSONDecodeError) as exc:
         logger.warning("Could not load registry from %s: %s", registry_path, exc)
         return {}
-    registry: dict[str, ModelLifecycle] = {}
+    registry: dict[str, DeprecatedModel] = {}
     for entry in data.get("models", []):
-        lc = _entry_to_lifecycle(entry)
-        registry[lc.model] = lc
+        dm = _entry_to_deprecated(entry)
+        registry[dm.model] = dm
     return registry
 
 
-def save_registry(registry: dict[str, ModelLifecycle], path: Path) -> None:
+def save_registry(registry: dict[str, DeprecatedModel], path: Path) -> None:
     """Save registry to JSON file.
 
     Sorts entries by (provider, model) for clean diffs.
 
     Args:
-        registry: Dictionary mapping model names to ModelLifecycle objects.
+        registry: Dictionary mapping model names to DeprecatedModel objects.
         path: Path to write the registry JSON file.
     """
-    sorted_entries = sorted(registry.values(), key=lambda lc: (lc.provider, lc.model))
+    sorted_entries = sorted(registry.values(), key=lambda dm: (dm.provider, dm.model))
     data = {
         "updated_at": datetime.now(tz=UTC).isoformat(),
-        "models": [_lifecycle_to_dict(lc) for lc in sorted_entries],
+        "models": [_deprecated_to_dict(dm) for dm in sorted_entries],
     }
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
 
 
 def merge_registries(
-    static: dict[str, ModelLifecycle],
-    feed: list[ModelLifecycle],
-) -> dict[str, ModelLifecycle]:
+    static: dict[str, DeprecatedModel],
+    feed: list[DeprecatedModel],
+) -> dict[str, DeprecatedModel]:
     """Merge static registry with live feed data.
 
     Feed entries take priority over static entries for the same model.
@@ -115,16 +109,16 @@ def merge_registries(
     return merged
 
 
-DEPRECATION_REGISTRY: dict[str, ModelLifecycle] = load_registry()
+DEPRECATION_REGISTRY: dict[str, DeprecatedModel] = load_registry()
 
 
-def check_deprecation(model: str) -> ModelLifecycle | None:
+def check_deprecation(model: str) -> DeprecatedModel | None:
     """Look up deprecation info for a model.
 
     Handles date-suffixed model names (e.g. "gpt-4o-2024-08-06" -> "gpt-4o")
     by stripping the suffix and retrying the lookup.
 
-    Returns ModelLifecycle if the model is deprecated/retiring, None otherwise.
+    Returns DeprecatedModel if the model is deprecated/retiring, None otherwise.
     """
     result = DEPRECATION_REGISTRY.get(model)
     if result is not None:

--- a/src/issue_reporter.py
+++ b/src/issue_reporter.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING
 
 
 if TYPE_CHECKING:
-    from src.deprecations import ModelLifecycle
+    from src.deprecations import DeprecatedModel
     from src.models import ScanMatch
 
 
@@ -32,7 +32,7 @@ class DeprecationAlert:
     """A deprecated model reference found in the codebase."""
 
     match: ScanMatch
-    lifecycle: ModelLifecycle
+    lifecycle: DeprecatedModel
 
 
 def create_issues(
@@ -186,48 +186,41 @@ def _create_issue(
     return False
 
 
-def _build_title(lifecycle: ModelLifecycle) -> str:
+def _build_title(lifecycle: DeprecatedModel) -> str:
     """Build the issue title."""
     status_emoji = {"retiring": "⚠️", "deprecated": "🚫", "shutdown": "🔴"}
     emoji = status_emoji.get(lifecycle.status, "⚠️")
-    return f"{emoji} Deprecated model: {lifecycle.model}"
+    return f"{emoji} Modèle déprécié : {lifecycle.model}"
 
 
 def _build_body(
-    lifecycle: ModelLifecycle,
+    lifecycle: DeprecatedModel,
     alerts: list[DeprecationAlert],
 ) -> str:
     """Build the issue body in Markdown."""
     lines = [
-        f"## Model `{lifecycle.model}` is {lifecycle.status}",
+        f"## Le modèle `{lifecycle.model}` est {lifecycle.status}",
         "",
-        f"**Provider:** {lifecycle.provider}",
-        f"**Status:** {lifecycle.status}",
+        f"**Provider :** {lifecycle.provider}",
+        f"**Statut :** {lifecycle.status}",
     ]
 
     if lifecycle.shutdown_date:
-        lines.append(f"**Shutdown date:** {lifecycle.shutdown_date.isoformat()}")
-    if lifecycle.replacement:
-        lines.append(f"**Recommended replacement:** `{lifecycle.replacement}`")
-    if lifecycle.note:
-        lines.append(f"**Note:** {lifecycle.note}")
+        lines.append(f"**Date d'arrêt :** {lifecycle.shutdown_date.isoformat()}")
 
-    lines.extend(["", "### Affected files", ""])
-    lines.append("| File | Line |")
-    lines.append("|------|------|")
+    lines.extend(["", "### Fichiers affectés", ""])
+    lines.append("| Fichier | Ligne |")
+    lines.append("|---------|-------|")
     lines.extend(f"| `{alert.match.file}` | {alert.match.line} |" for alert in alerts)
 
-    replacement_text = (
-        f"`{lifecycle.replacement}`" if lifecycle.replacement else "a supported model"
-    )
     lines.extend(
         [
             "",
-            "### Action required",
-            f"Migrate from `{lifecycle.model}` to {replacement_text} before the shutdown date.",
+            "### Action requise",
+            "Migrer vers un modèle supporté avant la date d'arrêt.",
             "",
             "---",
-            "*This issue was automatically created by the LLM Configuration Scanner.*",
+            "*Cette issue a été créée automatiquement par le LLM Configuration Scanner.*",
         ]
     )
 

--- a/src/main.py
+++ b/src/main.py
@@ -108,7 +108,6 @@ def _build_deprecated_summary(alerts: list[DeprecationAlert]) -> list[dict[str, 
             "model": alert.lifecycle.model,
             "provider": alert.lifecycle.provider,
             "status": alert.lifecycle.status,
-            "replacement": alert.lifecycle.replacement or "",
         }
         if alert.lifecycle.shutdown_date:
             entry["shutdown_date"] = alert.lifecycle.shutdown_date.isoformat()
@@ -133,9 +132,8 @@ def _print_summary(matches: list[ScanMatch], alerts: list[DeprecationAlert]) -> 
                 continue
             seen.add(alert.lifecycle.model)
             lc = alert.lifecycle
-            replacement = f" → {lc.replacement}" if lc.replacement else ""
             shutdown = f" (shutdown: {lc.shutdown_date})" if lc.shutdown_date else ""
-            logger.info("  - %s [%s]%s%s", lc.model, lc.status, replacement, shutdown)
+            logger.info("  - %s [%s]%s", lc.model, lc.status, shutdown)
 
 
 def _set_github_output(name: str, value: str) -> None:

--- a/src/update_registry.py
+++ b/src/update_registry.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from src.deprecation_feed import fetch_deprecations
 from src.deprecations import (
     _DEFAULT_REGISTRY_PATH,
-    ModelLifecycle,
+    DeprecatedModel,
     load_registry,
     merge_registries,
     save_registry,
@@ -71,7 +71,7 @@ def _create_feed_failure_issue(error_detail: str) -> None:
         "--label",
         _ISSUE_LABEL,
     ]
-    assignees = os.environ.get("REGISTRY_ASSIGNEES", "")
+    assignees = os.environ.get("LLM_SCAN_ASSIGNEES", "")
     if assignees:
         cmd.extend(["--assignee", assignees])
 
@@ -95,21 +95,20 @@ _README_MARKER_START = "<!-- REGISTRY_START -->"
 _README_MARKER_END = "<!-- REGISTRY_END -->"
 
 
-def _generate_registry_table(registry: dict[str, ModelLifecycle]) -> str:
+def _generate_registry_table(registry: dict[str, DeprecatedModel]) -> str:
     """Genere le tableau Markdown des modeles deprecies pour le README."""
-    sorted_entries = sorted(registry.values(), key=lambda lc: (lc.provider, lc.model))
+    sorted_entries = sorted(registry.values(), key=lambda dm: (dm.provider, dm.model))
     lines = [
-        "| Model | Provider | Status | Shutdown date | Replacement |",
-        "|---|---|---|---|---|",
+        "| Model | Provider | Status | Shutdown date |",
+        "|---|---|---|---|",
     ]
-    for lc in sorted_entries:
-        shutdown = lc.shutdown_date.isoformat() if lc.shutdown_date else ""
-        replacement = lc.replacement or ""
-        lines.append(f"| {lc.model} | {lc.provider} | {lc.status} | {shutdown} | {replacement} |")
+    for dm in sorted_entries:
+        shutdown = dm.shutdown_date.isoformat() if dm.shutdown_date else ""
+        lines.append(f"| {dm.model} | {dm.provider} | {dm.status} | {shutdown} |")
     return "\n".join(lines)
 
 
-def update_readme(registry: dict[str, ModelLifecycle], readme_path: Path) -> bool:
+def update_readme(registry: dict[str, DeprecatedModel], readme_path: Path) -> bool:
     """Met a jour la section auto-generee du README avec le registre actuel.
 
     Args:
@@ -176,9 +175,6 @@ def update_registry(registry_path: Path) -> int:
 
     save_registry(merged, registry_path)
     logger.info("Registre sauvegarde dans %s", registry_path)
-
-    readme_path = registry_path.parent.parent / "README.md"
-    update_readme(merged, readme_path)
 
     return len(feed)
 

--- a/template-workflow.yml
+++ b/template-workflow.yml
@@ -8,15 +8,8 @@ name: LLM Configuration Scan
 
 on:
   push:
-    branches: [main]
-    paths:
-      - "**/*.py"
-      - "**/*.yml"
-      - "**/*.yaml"
-      - "**/*.json"
-      - "**/*.toml"
-      - "**/*.env"
-      - "**/Dockerfile"
+    tags:
+      - "v*"
   schedule:
     - cron: "0 8 1,15 * *"  # Bi-weekly: 1st and 15th of each month at 8:00 UTC
   workflow_dispatch:

--- a/tests/features/deprecations.feature
+++ b/tests/features/deprecations.feature
@@ -1,19 +1,18 @@
 Feature: Model deprecation detection
   The scanner should identify deprecated or retiring models
-  and provide lifecycle information including shutdown dates and replacements.
+  and provide deprecation information including shutdown dates.
 
   Scenario Outline: Detect deprecated models
     Given a model name "<model>"
     When I check its deprecation status
     Then the model should be "<status>"
-    And the replacement should be "<replacement>"
 
     Examples:
-      | model                  | status     | replacement           |
-      | gpt-3.5-turbo          | deprecated | gpt-4.1-mini          |
-      | gpt-4o                 | retiring   | gpt-4.1               |
-      | o1-preview             | shutdown   | o3                    |
-      | text-embedding-ada-002 | retiring   | text-embedding-3-small |
+      | model                  | status     |
+      | gpt-3.5-turbo          | deprecated |
+      | gpt-4o                 | retiring   |
+      | o1-preview             | shutdown   |
+      | text-embedding-ada-002 | retiring   |
 
   Scenario Outline: Date-suffixed models match base deprecation
     Given a model name "<model>"

--- a/tests/features/issue_reporter.feature
+++ b/tests/features/issue_reporter.feature
@@ -1,6 +1,7 @@
 Feature: GitHub Issue creation for deprecated models
   The issue reporter should create well-formatted GitHub issues
   for deprecated models, with deduplication and dry-run support.
+  Issue content is in French.
 
   Scenario: Build title for retiring model
     Given a model lifecycle for "gpt-4o" with status "retiring"
@@ -24,9 +25,9 @@ Feature: GitHub Issue creation for deprecated models
     Given a deprecation alert for "gpt-4o" in file "config.py" at line 5
     When I build the issue body
     Then the body should contain "gpt-4o"
-    And the body should contain "### Affected files"
+    And the body should contain "### Fichiers affectés"
     And the body should contain "config.py"
-    And the body should contain "### Action required"
+    And the body should contain "### Action requise"
 
   Scenario: Dry run does not call gh CLI
     Given a list of deprecation alerts for models "gpt-4o,gpt-3.5-turbo"

--- a/tests/features/update_registry.feature
+++ b/tests/features/update_registry.feature
@@ -10,12 +10,6 @@ Feature: Mise a jour du registre depuis le flux deprecations.info
     Then the registry should have 3 models
     And the registry should contain "claude-3-opus"
 
-  Scenario: La mise a jour ecrase un modele existant depuis le flux
-    Given a registry with model "gpt-4o" replacement "gpt-4.1"
-    And a feed returning model "gpt-4o" with replacement "gpt-5"
-    When I run the registry update
-    Then the registry entry "gpt-4o" should have replacement "gpt-5"
-
   Scenario: Un flux vide laisse le registre inchange
     Given a registry with 2 models
     And a feed returning no data

--- a/tests/test_coherence.py
+++ b/tests/test_coherence.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+
 from src.deprecations import DEPRECATION_REGISTRY
 from src.patterns import find_matches_in_line
 

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from pathlib import Path
 
 from pytest_bdd import given, parsers, scenarios, then, when
-from src.deprecations import ModelLifecycle, check_deprecation
+
+from src.deprecations import DeprecatedModel, check_deprecation
 from src.issue_reporter import DeprecationAlert
 from src.scanner import scan_directory
 
@@ -25,7 +26,7 @@ def given_model_name(model: str) -> str:
     "I check its deprecation status",
     target_fixture="deprecation_result",
 )
-def check_deprecation_status(model_name: str) -> ModelLifecycle | None:
+def check_deprecation_status(model_name: str) -> DeprecatedModel | None:
     return check_deprecation(model_name)
 
 
@@ -46,7 +47,7 @@ def scan_and_check_deprecations(scan_dir: Path, repo_name: str) -> list[Deprecat
 @then(
     parsers.cfparse('the model should be "{status}"'),
 )
-def check_status(deprecation_result: ModelLifecycle | None, status: str) -> None:
+def check_status(deprecation_result: DeprecatedModel | None, status: str) -> None:
     assert deprecation_result is not None, "Expected model to be in deprecation registry"
     assert deprecation_result.status == status, (
         f"Expected status '{status}', got '{deprecation_result.status}'"
@@ -54,19 +55,9 @@ def check_status(deprecation_result: ModelLifecycle | None, status: str) -> None
 
 
 @then(
-    parsers.cfparse('the replacement should be "{replacement}"'),
-)
-def check_replacement(deprecation_result: ModelLifecycle | None, replacement: str) -> None:
-    assert deprecation_result is not None, "Expected model to be in deprecation registry"
-    assert deprecation_result.replacement == replacement, (
-        f"Expected replacement '{replacement}', got '{deprecation_result.replacement}'"
-    )
-
-
-@then(
     "the model should not be deprecated",
 )
-def check_not_deprecated(deprecation_result: ModelLifecycle | None) -> None:
+def check_not_deprecated(deprecation_result: DeprecatedModel | None) -> None:
     assert deprecation_result is None, (
         f"Expected model to NOT be in deprecation registry, got {deprecation_result}"
     )

--- a/tests/test_issue_reporter.py
+++ b/tests/test_issue_reporter.py
@@ -6,7 +6,8 @@ from datetime import date
 from unittest.mock import patch
 
 from pytest_bdd import given, parsers, scenarios, then, when
-from src.deprecations import ModelLifecycle
+
+from src.deprecations import DeprecatedModel
 from src.issue_reporter import (
     DeprecationAlert,
     _build_body,
@@ -24,14 +25,12 @@ def _make_lifecycle(
     model: str,
     status: str = "retiring",
     provider: str = "openai",
-    replacement: str = "gpt-4.1",
-) -> ModelLifecycle:
-    return ModelLifecycle(
+) -> DeprecatedModel:
+    return DeprecatedModel(
         model=model,
         provider=provider,
         status=status,
         shutdown_date=date(2026, 10, 1),
-        replacement=replacement,
     )
 
 
@@ -60,7 +59,7 @@ def _make_alert(
     parsers.cfparse('a model lifecycle for "{model}" with status "{status}"'),
     target_fixture="lifecycle",
 )
-def given_lifecycle(model: str, status: str) -> ModelLifecycle:
+def given_lifecycle(model: str, status: str) -> DeprecatedModel:
     return _make_lifecycle(model, status=status)
 
 
@@ -111,7 +110,7 @@ def given_assignees(assignees_str: str) -> list[str]:
     "I build the issue title",
     target_fixture="title",
 )
-def build_title(lifecycle: ModelLifecycle) -> str:
+def build_title(lifecycle: DeprecatedModel) -> str:
     return _build_title(lifecycle)
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -7,7 +7,8 @@ from pathlib import Path
 from unittest.mock import patch
 
 from pytest_bdd import given, parsers, scenarios, then, when
-from src.deprecations import ModelLifecycle
+
+from src.deprecations import DeprecatedModel
 from src.issue_reporter import DeprecationAlert
 from src.main import _build_deprecated_summary, _find_deprecated, _set_github_output, parse_args
 from src.models import ScanMatch
@@ -56,12 +57,11 @@ def given_scan_matches(models: str) -> list[ScanMatch]:
     target_fixture="dup_alerts",
 )
 def given_duplicate_alerts(model: str, count: int) -> list[DeprecationAlert]:
-    lifecycle = ModelLifecycle(
+    lifecycle = DeprecatedModel(
         model=model,
         provider="openai",
         status="retiring",
         shutdown_date=date(2026, 10, 1),
-        replacement="gpt-4.1",
     )
     return [
         DeprecationAlert(

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pytest_bdd import given, parsers, scenarios, then, when
+
 from src.patterns import find_matches_in_line
 
 

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from pytest_bdd import parsers, scenarios, then, when
+
 from src.models import ScanResult
 from src.scanner import scan_directory
 
@@ -35,6 +36,3 @@ def check_scan_match_count(scan_result: ScanResult, count: int) -> None:
 def check_result_contains_model(scan_result: ScanResult, model: str) -> None:
     models = [m.model for m in scan_result.matches]
     assert model in models, f"Expected model '{model}' in {models}"
-
-
-

--- a/tests/test_update_registry.py
+++ b/tests/test_update_registry.py
@@ -8,7 +8,8 @@ from unittest.mock import patch
 
 import pytest
 from pytest_bdd import given, parsers, scenarios, then, when
-from src.deprecations import ModelLifecycle, load_registry, save_registry
+
+from src.deprecations import DeprecatedModel, load_registry, save_registry
 from src.update_registry import update_registry
 
 
@@ -18,14 +19,12 @@ scenarios("features/update_registry.feature")
 def _make_lifecycle(
     model: str,
     provider: str = "openai",
-    replacement: str | None = "gpt-4.1",
-) -> ModelLifecycle:
-    return ModelLifecycle(
+) -> DeprecatedModel:
+    return DeprecatedModel(
         model=model,
         provider=provider,
         status="retiring",
         shutdown_date=date(2026, 10, 1),
-        replacement=replacement,
     )
 
 
@@ -51,37 +50,15 @@ def given_registry_with_n_models(registry_path: Path, count: int) -> Path:
     parsers.cfparse('a feed returning {count:d} new model "{model}" from "{provider}"'),
     target_fixture="mock_feed",
 )
-def given_feed_with_new_model(
-    model: str, provider: str, count: int
-) -> list[ModelLifecycle]:
+def given_feed_with_new_model(model: str, provider: str, count: int) -> list[DeprecatedModel]:
     return [_make_lifecycle(model, provider=provider.lower())]
-
-
-@given(
-    parsers.cfparse('a registry with model "{model}" replacement "{replacement}"'),
-    target_fixture="seed_registry",
-)
-def given_registry_with_specific_model(
-    registry_path: Path, model: str, replacement: str
-) -> Path:
-    models = {model: _make_lifecycle(model, replacement=replacement)}
-    save_registry(models, registry_path)
-    return registry_path
-
-
-@given(
-    parsers.cfparse('a feed returning model "{model}" with replacement "{replacement}"'),
-    target_fixture="mock_feed",
-)
-def given_feed_with_replacement(model: str, replacement: str) -> list[ModelLifecycle]:
-    return [_make_lifecycle(model, replacement=replacement)]
 
 
 @given(
     "a feed returning no data",
     target_fixture="mock_feed",
 )
-def given_empty_feed() -> list[ModelLifecycle]:
+def given_empty_feed() -> list[DeprecatedModel]:
     return []
 
 
@@ -92,9 +69,7 @@ def given_empty_feed() -> list[ModelLifecycle]:
     "I run the registry update",
     target_fixture="update_result",
 )
-def run_update(
-    registry_path: Path, mock_feed: list[ModelLifecycle]
-) -> dict[str, int]:
+def run_update(registry_path: Path, mock_feed: list[DeprecatedModel]) -> dict[str, int]:
     with (
         patch("src.update_registry.fetch_deprecations", return_value=mock_feed),
         patch("src.update_registry._create_feed_failure_issue"),
@@ -107,9 +82,7 @@ def run_update(
 
 
 @then(parsers.cfparse("the registry should have {count:d} models"))
-def check_registry_count(
-    registry_path: Path, update_result: dict[str, int], count: int
-) -> None:
+def check_registry_count(registry_path: Path, update_result: dict[str, int], count: int) -> None:
     registry = load_registry(registry_path)
     assert len(registry) == count, (
         f"Expected {count} models, got {len(registry)}: {list(registry.keys())}"
@@ -122,15 +95,3 @@ def check_registry_contains(
 ) -> None:
     registry = load_registry(registry_path)
     assert model in registry, f"Expected '{model}' in registry, got {list(registry.keys())}"
-
-
-@then(parsers.cfparse('the registry entry "{model}" should have replacement "{replacement}"'))
-def check_registry_replacement(
-    registry_path: Path, update_result: dict[str, int], model: str, replacement: str
-) -> None:
-    registry = load_registry(registry_path)
-    entry = registry.get(model)
-    assert entry is not None, f"Model '{model}' not found in registry"
-    assert entry.replacement == replacement, (
-        f"Expected replacement '{replacement}', got '{entry.replacement}'"
-    )


### PR DESCRIPTION
## Summary

- Renomme `ModelLifecycle` → `DeprecatedModel` et retire les champs `replacement` et `note` du modèle, du registre et de toute la chaîne (feed, issues, CLI, README)
- Traduit le contenu des issues GitHub en français (titre, body, sections)
- Corrige l'ordre du workflow : le README est mis à jour **après** détection de changements dans `registry.json`, pas avant
- Change le trigger du template-workflow de `push on main` à `push tags: v*` pour éviter les scans redondants

## Test plan

- [x] 111 tests passent (`PYTHONPATH=. python -m pytest tests/ -v`)
- [x] Lint clean (`ruff check src/ tests/ && ruff format --check src/ tests/`)
- [x] Aucune trace de `ModelLifecycle`, `replacement` ou `note` dans src/, data/, tests/
- [ ] Vérifier que le diagramme Mermaid du README reflète le bon ordre

🤖 Generated with [Claude Code](https://claude.com/claude-code)