### PR TITLE
fix: continue workflow si Claude validation échoue

### DIFF
--- a/.github/workflows/update-registry.yml
+++ b/.github/workflows/update-registry.yml
@@ -76,6 +76,7 @@ jobs:
 
       - name: Ajuster les patterns regex avec Claude
         if: steps.push-branch.outputs.branch != ''
+        continue-on-error: true
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary

- Ajoute `continue-on-error: true` à l'étape Claude Code pour que la PR soit créée même si la validation échoue (ex: GitHub App pas installée)

## Action requise

Installer le Claude Code GitHub App sur le repo : https://github.com/apps/claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)