### PR TITLE
fix: retirer le merge automatique du workflow

### DIFF
--- a/.github/workflows/update-registry.yml
+++ b/.github/workflows/update-registry.yml
@@ -109,9 +109,3 @@ jobs:
             --head "${{ steps.push-branch.outputs.branch }}" \
             --base main
 
-      - name: Merger la PR
-        if: steps.push-branch.outputs.branch != ''
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh pr merge "${{ steps.push-branch.outputs.branch }}" --squash --admin --delete-branch

--- a/README.md
+++ b/README.md
@@ -110,7 +110,6 @@ flowchart TD
     F -->|Oui| H[Mettre à jour<br>le README]
     H --> I[Claude Code valide<br>et ajuste les regex]
     I --> J[Créer PR]
-    J --> K[Merge PR]
 ```
 
 Le workflow :
@@ -119,7 +118,7 @@ Le workflow :
 2. Fusionne avec le registre existant
 3. Si des changements sont détectés : met à jour le README et pousse sur une branche
 4. Claude Code valide et ajuste les patterns regex si nécessaire
-5. Crée une PR et la merge automatiquement
+5. Crée une PR pour révision
 
 Si le flux est inaccessible, une issue GitHub est créée et assignée aux mainteneurs.
 


### PR DESCRIPTION
## Summary

- Retire l'étape de merge automatique du workflow (le GITHUB_TOKEN ne peut pas bypasser les branch protection rules)
- La PR est maintenant créée pour révision manuelle
- Met à jour le diagramme Mermaid et la doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)