### PR TITLE
feat: post-audit improvements

### DIFF
--- a/src/deprecations.py
+++ b/src/deprecations.py
@@ -44,6 +44,10 @@ def _validate_entry(entry: dict[str, Any]) -> bool:
     if not isinstance(model, str) or not model:
         return False
 
+    # Reject category headers from deprecations.info (e.g. "Chat model updates")
+    if " " in model:
+        return False
+
     provider = entry.get("provider")
     if provider not in _VALID_PROVIDERS:
         return False
@@ -142,6 +146,12 @@ def merge_registries(
 
 
 DEPRECATION_REGISTRY: dict[str, DeprecatedModel] = load_registry()
+
+
+def reload_deprecation_registry(path: Path | None = None) -> None:
+    """Reload the global deprecation registry from disk."""
+    global DEPRECATION_REGISTRY
+    DEPRECATION_REGISTRY = load_registry(path)
 
 
 def check_deprecation(model: str) -> DeprecatedModel | None:

--- a/src/patterns.py
+++ b/src/patterns.py
@@ -105,7 +105,7 @@ def _build_patterns() -> list[ModelPattern]:
     _add("openai", "embedding", r"\btext-embedding-ada-002\b")
 
     # --- Voyage Embeddings ---
-    _add("voyage", "embedding", r"\bvoyage-(?:large|code|lite)-\d+\b")
+    _add("voyage", "embedding", r"\bvoyage-(?:[a-z]+-)*\d+(?:-[a-z0-9]+)*\b")
 
     return patterns
 

--- a/tests/features/patterns.feature
+++ b/tests/features/patterns.feature
@@ -45,6 +45,10 @@ Feature: LLM model pattern detection
       | model = "text-embedding-ada-002"           | text-embedding-ada-002    | openai   |
       | model = "voyage-large-2"                  | voyage-large-2            | voyage   |
       | model: voyage-code-3                       | voyage-code-3             | voyage   |
+      | model = "voyage-lite-3"                    | voyage-lite-3             | voyage   |
+      | model = "voyage-finance-2"                 | voyage-finance-2          | voyage   |
+      | model: voyage-3                            | voyage-3                  | voyage   |
+      | model = "voyage-3-lite"                    | voyage-3-lite             | voyage   |
       | model = "gemini-embedding-001"             | gemini-embedding-001      | google   |
       | model: gemini-embedding-exp                 | gemini-embedding-exp      | google   |
 

--- a/tests/features/validate_patterns.feature
+++ b/tests/features/validate_patterns.feature
@@ -1,0 +1,28 @@
+Feature: Validate pattern coverage against registry
+  The validate_patterns module should check which registry
+  models are matched by existing regex patterns.
+
+  Scenario: All known models are covered
+    Given a temporary registry with the following models:
+      | model              | provider  | status     |
+      | gpt-4o             | openai    | retiring   |
+      | claude-3-opus      | anthropic | deprecated |
+    When I validate pattern coverage
+    Then I should have 0 unmatched models
+
+  Scenario: Unknown models are reported as unmatched
+    Given a temporary registry with the following models:
+      | model              | provider  | status     |
+      | gpt-4o             | openai    | retiring   |
+      | fake-model-xyz     | openai    | deprecated |
+    When I validate pattern coverage
+    Then I should have 1 unmatched models
+
+  Scenario: Category entries with spaces are ignored
+    Given a temporary registry with the following models:
+      | model              | provider  | status     |
+      | Chat model updates | openai    | retiring   |
+      | gpt-4o             | openai    | retiring   |
+    When I validate pattern coverage
+    Then I should have 0 unmatched models
+    And "chat model updates" should not appear in matched or unmatched

--- a/tests/test_validate_patterns.py
+++ b/tests/test_validate_patterns.py
@@ -1,0 +1,65 @@
+"""BDD step definitions for validate_patterns coverage tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from pytest_bdd import given, parsers, scenarios, then, when
+
+from src.validate_patterns import validate_coverage
+
+
+scenarios("features/validate_patterns.feature")
+
+
+@given(
+    "a temporary registry with the following models:",
+    target_fixture="registry_path",
+)
+def given_temp_registry(tmp_path: Path, datatable: list[list[str]]) -> Path:
+    headers = datatable[0]
+    model_idx = headers.index("model")
+    provider_idx = headers.index("provider")
+    status_idx = headers.index("status")
+    models = []
+    for row in datatable[1:]:
+        models.append(
+            {
+                "model": row[model_idx],
+                "provider": row[provider_idx],
+                "status": row[status_idx],
+                "shutdown_date": None,
+            }
+        )
+    registry_file = tmp_path / "registry.json"
+    registry_file.write_text(json.dumps({"models": models}, indent=2), encoding="utf-8")
+    return registry_file
+
+
+@when(
+    "I validate pattern coverage",
+    target_fixture="coverage_results",
+)
+def validate(registry_path: Path) -> dict[str, list[str]]:
+    return validate_coverage(registry_path)
+
+
+@then(
+    parsers.cfparse("I should have {count:d} unmatched models"),
+)
+def check_unmatched_count(coverage_results: dict[str, list[str]], count: int) -> None:
+    actual = len(coverage_results["unmatched"])
+    assert actual == count, (
+        f"Expected {count} unmatched, got {actual}: {coverage_results['unmatched']}"
+    )
+
+
+@then(
+    parsers.cfparse('"{name}" should not appear in matched or unmatched'),
+)
+def check_not_in_results(coverage_results: dict[str, list[str]], name: str) -> None:
+    all_models = coverage_results["matched"] + coverage_results["unmatched"]
+    assert name not in all_models, (
+        f"'{name}' should not appear in results but found in {all_models}"
+    )


### PR DESCRIPTION
## Summary
- Filter category entries (names with spaces) in `_validate_entry()` for defense in depth
- Make Voyage embedding pattern flexible to match future model formats (`voyage-3`, `voyage-3-lite`, `voyage-finance-2`)
- Add 3 BDD scenarios for `validate_patterns`: coverage check, unmatched models, and category filtering
- Add `reload_deprecation_registry()` for runtime registry reload without restart

## Test plan
- [x] All 213 tests pass locally (`PYTHONPATH=. python -m pytest tests/ -v`)
- [x] Ruff lint + format clean
- [ ] CI/CD pipeline passes

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)