### PR TITLE
ci: add davebulaval as reviewer on registry update PRs

### DIFF
--- a/.github/workflows/update-registry.yml
+++ b/.github/workflows/update-registry.yml
@@ -115,4 +115,5 @@ jobs:
             --title "chore: mise a jour du registre de deprecation" \
             --body "Mise a jour automatique du registre et du README depuis [deprecations.info](https://deprecations.info/)." \
             --head "${{ steps.push-branch.outputs.branch }}" \
-            --base main
+            --base main \
+            --reviewer davebulaval


### PR DESCRIPTION
## Summary
- Ajoute `--reviewer davebulaval` à la commande `gh pr create` dans le workflow de mise à jour du registre

🤖 Generated with [Claude Code](https://claude.com/claude-code)