### PR TITLE
refactor: remove emojis from issue titles

### DIFF
--- a/.github/workflows/update-registry.yml
+++ b/.github/workflows/update-registry.yml
@@ -115,4 +115,5 @@ jobs:
             --title "chore: mise a jour du registre de deprecation" \
             --body "Mise a jour automatique du registre et du README depuis [deprecations.info](https://deprecations.info/)." \
             --head "${{ steps.push-branch.outputs.branch }}" \
-            --base main
+            --base main \
+            --reviewer davebulaval

--- a/src/issue_reporter.py
+++ b/src/issue_reporter.py
@@ -208,9 +208,7 @@ def _create_issue(
 
 def _build_title(lifecycle: DeprecatedModel) -> str:
     """Build the issue title."""
-    status_emoji = {"retiring": "⚠️", "deprecated": "🚫", "shutdown": "🔴"}
-    emoji = status_emoji.get(lifecycle.status, "⚠️")
-    return f"{emoji} Modèle déprécié : {lifecycle.model}"
+    return f"Modèle déprécié : {lifecycle.model}"
 
 
 def _build_body(

--- a/tests/features/issue_reporter.feature
+++ b/tests/features/issue_reporter.feature
@@ -7,19 +7,19 @@ Feature: GitHub Issue creation for deprecated models
     Given a model lifecycle for "gpt-4o" with status "retiring"
     When I build the issue title
     Then the title should contain "gpt-4o"
-    And the title should start with "⚠️"
+    And the title should start with "Modèle déprécié"
 
   Scenario: Build title for deprecated model
     Given a model lifecycle for "gpt-3.5-turbo" with status "deprecated"
     When I build the issue title
     Then the title should contain "gpt-3.5-turbo"
-    And the title should start with "🚫"
+    And the title should start with "Modèle déprécié"
 
   Scenario: Build title for shutdown model
     Given a model lifecycle for "o1-preview" with status "shutdown"
     When I build the issue title
     Then the title should contain "o1-preview"
-    And the title should start with "🔴"
+    And the title should start with "Modèle déprécié"
 
   Scenario: Build body contains required sections
     Given a deprecation alert for "gpt-4o" in file "config.py" at line 5


### PR DESCRIPTION
## Summary
- Retire les emojis des titres d'issues generees
- Avant : `🔴 Modèle déprécié : gpt-4o`
- Apres : `Modèle déprécié : gpt-4o`

Generated with [Claude Code](https://claude.com/claude-code)