### PR TITLE
feat: update regex patterns for full registry coverage

### DIFF
--- a/src/patterns.py
+++ b/src/patterns.py
@@ -59,21 +59,49 @@ def _build_patterns() -> list[ModelPattern]:
     _add("openai", "llm", r"\bgpt-4\.1(?:-(?:mini|nano))?(?:-\d{4}-\d{2}-\d{2})?\b")
     _add("openai", "llm", r"\bgpt-4o-audio-preview(?:-\d{4}-\d{2}-\d{2})?\b")
     _add("openai", "llm", r"\bgpt-4o-realtime-preview(?:-\d{4}-\d{2}-\d{2})?\b")
+    _add("openai", "llm", r"\bgpt-4o-mini-(?:audio|realtime)-preview\b")
     _add("openai", "llm", r"\bgpt-4o(?:-mini)?(?:-\d{4}-\d{2}-\d{2})?\b")
+    _add("openai", "llm", r"\bgpt-4-turbo-preview-completions\b")
     _add("openai", "llm", r"\bgpt-4-turbo(?:-preview)?(?:-\d{4}-\d{2}-\d{2})?\b")
+    _add("openai", "llm", r"\bgpt-4-vision-preview\b")
+    _add("openai", "llm", r"\bgpt-4-\d{4}-vision-preview\b")
+    _add("openai", "llm", r"\bgpt-4-\d{4}-preview\b")
+    # gpt-4-MMDD: negative lookahead prevents matching YYYY-MM-DD date suffixes
+    _add("openai", "llm", r"\bgpt-4-\d{4}(?!-\d{2}-\d{2})\b")
+    _add("openai", "llm", r"\bgpt-4-32k-\d{4}\b")
     # gpt-4 base: negative lookahead prevents matching gpt-4.1, gpt-4.5, gpt-4o, gpt-4-turbo
     _add("openai", "llm", r"\bgpt-4(?!\.\d|o|-turbo)(?:-32k)?(?:-\d{4}-\d{2}-\d{2})?\b")
+    _add("openai", "llm", r"\bgpt-3\.5-turbo-instruct\b")
+    _add("openai", "llm", r"\bgpt-3\.5-turbo-16k(?:-\d{4})?\b")
     _add("openai", "llm", r"\bgpt-3\.5-turbo(?:-\d{4})?\b")
     _add("openai", "llm", r"\bchatgpt-4o-latest\b")
     _add("openai", "llm", r"\bo1(?:-preview|-mini|-pro)?\b", context_required=True)
     _add("openai", "llm", r"\bo3(?:-mini|-pro|-deep-research)?\b", context_required=True)
     _add("openai", "llm", r"\bo4-mini\b")
     _add("openai", "llm", r"\bcodex-mini(?:-latest)?\b")
-    _add("openai", "llm", r"\btext-moderation\b")
+    _add("openai", "llm", r"\bdall-e-[23]\b")
+    _add("openai", "llm", r"\bsora-\d+(?:-pro)?(?:-\d{4}-\d{2}-\d{2})?\b")
+    # Legacy text generation models
+    _add("openai", "llm", r"\btext-(?:ada|babbage|curie|davinci)-\d{3}\b")
+    _add("openai", "llm", r"\btext-davinci-edit-\d{3}\b")
+    _add("openai", "llm", r"\btext-moderation(?:-(?:\d{3}|latest|stable))?\b")
+    # Legacy code models
+    _add("openai", "llm", r"\bcode-(?:cushman|davinci)-\d{3}\b")
+    _add("openai", "llm", r"\bcode-davinci-edit-\d{3}\b")
+    _add("openai", "llm", r"\bcode-search-(?:ada|babbage)-(?:code|text)-\d{3}\b")
+    # Legacy search and similarity
+    _add("openai", "llm", r"\btext-search-(?:ada|babbage|curie|davinci)-(?:doc|query)-\d{3}\b")
+    _add("openai", "llm", r"\btext-similarity-(?:ada|babbage|curie|davinci)-\d{3}\b")
+    # Generic legacy base models (require context; lookbehind prevents matching within compound
+    # names like text-embedding-ada-002 where ada appears after a dash separator)
+    _add("openai", "llm", r"(?<![a-z0-9-])ada\b", context_required=True)
+    _add("openai", "llm", r"(?<![a-z0-9-])babbage(?:-\d{3})?\b", context_required=True)
+    _add("openai", "llm", r"(?<![a-z0-9-])curie\b", context_required=True)
+    _add("openai", "llm", r"(?<![a-z0-9-])davinci(?:-\d{3})?\b", context_required=True)
 
     # --- Anthropic ---
-    _add("anthropic", "llm", r"\bclaude-opus-4\b")
-    _add("anthropic", "llm", r"\bclaude-sonnet-4\b")
+    _add("anthropic", "llm", r"\bclaude-opus-4(?:-\d{8})?\b")
+    _add("anthropic", "llm", r"\bclaude-sonnet-4(?:-\d{8})?\b")
     _add("anthropic", "llm", r"\bclaude-3[\.-]7-sonnet(?:-\d{8})?\b")
     _add("anthropic", "llm", r"\bclaude-3[\.-]5-sonnet(?:-\d{8})?\b")
     _add("anthropic", "llm", r"\bclaude-3[\.-]5-haiku(?:-\d{8})?\b")
@@ -85,6 +113,8 @@ def _build_patterns() -> list[ModelPattern]:
     _add("anthropic", "llm", r"\bclaude-1\.\d\b")
 
     # --- Google LLM ---
+    _add("google", "llm", r"\bgemini-3(?:[\.-]\d+)?-(?:pro|flash)(?:-[a-z0-9]+)*\b")
+    _add("google", "llm", r"\bgemini-robotics-er-\d+[\.-]\d+(?:-[a-z0-9]+)*\b")
     _add("google", "llm", r"\bgemini-2[\.-]5-flash(?:-[a-z0-9]+)*\b")
     _add("google", "llm", r"\bgemini-2[\.-]5-pro(?:-[a-z0-9]+)*\b")
     _add("google", "llm", r"\bgemini-2[\.-]0-flash(?:-[a-z0-9]+)*\b")

--- a/tests/features/patterns.feature
+++ b/tests/features/patterns.feature
@@ -16,8 +16,10 @@ Feature: LLM model pattern detection
       | model: gpt-4-turbo-preview       | gpt-4-turbo-preview | openai   | llm        |
       | model = "gpt-4"                  | gpt-4              | openai    | llm        |
       | model: gpt-3.5-turbo             | gpt-3.5-turbo      | openai    | llm        |
-      | model_name = "claude-opus-4"     | claude-opus-4      | anthropic | llm        |
-      | model_name = "claude-sonnet-4"   | claude-sonnet-4    | anthropic | llm        |
+      | model_name = "claude-opus-4"              | claude-opus-4              | anthropic | llm        |
+      | model_name = "claude-opus-4-20250514"     | claude-opus-4-20250514     | anthropic | llm        |
+      | model_name = "claude-sonnet-4"            | claude-sonnet-4            | anthropic | llm        |
+      | model_name = "claude-sonnet-4-20250514"   | claude-sonnet-4-20250514   | anthropic | llm        |
       | model: claude-3.5-sonnet         | claude-3.5-sonnet  | anthropic | llm        |
       | model: claude-3.5-haiku          | claude-3.5-haiku   | anthropic | llm        |
       | model: claude-3-opus             | claude-3-opus      | anthropic | llm        |
@@ -76,23 +78,73 @@ Feature: LLM model pattern detection
     And the match type should be "llm"
 
     Examples:
-      | line                                         | model                             |
-      | model = "gpt-4.1"                           | gpt-4.1                           |
-      | model = "gpt-4.1-mini"                      | gpt-4.1-mini                      |
-      | model = "gpt-4.1-nano"                      | gpt-4.1-nano                      |
-      | model: gpt-5                                 | gpt-5                             |
-      | model = "gpt-5.1"                           | gpt-5.1                           |
-      | model = "gpt-5.2"                           | gpt-5.2                           |
-      | model: gpt-5-mini                            | gpt-5-mini                        |
-      | model = "o4-mini"                            | o4-mini                           |
-      | model = "codex-mini"                         | codex-mini                        |
-      | model = "codex-mini-latest"                  | codex-mini-latest                 |
-      | model = "gpt-4.5-preview"                   | gpt-4.5-preview                   |
-      | model: gpt-4-32k                             | gpt-4-32k                         |
-      | model = "gpt-4o-audio-preview-2024-10-01"   | gpt-4o-audio-preview-2024-10-01   |
-      | model: gpt-4o-realtime-preview-2024-10-01    | gpt-4o-realtime-preview-2024-10-01 |
-      | model = "chatgpt-4o-latest"                  | chatgpt-4o-latest                 |
-      | model: text-moderation                        | text-moderation                   |
+      | line                                              | model                              |
+      | model = "gpt-4.1"                                | gpt-4.1                            |
+      | model = "gpt-4.1-mini"                           | gpt-4.1-mini                       |
+      | model = "gpt-4.1-nano"                           | gpt-4.1-nano                       |
+      | model: gpt-5                                      | gpt-5                              |
+      | model = "gpt-5.1"                                | gpt-5.1                            |
+      | model = "gpt-5.2"                                | gpt-5.2                            |
+      | model: gpt-5-mini                                 | gpt-5-mini                         |
+      | model = "o4-mini"                                 | o4-mini                            |
+      | model = "codex-mini"                              | codex-mini                         |
+      | model = "codex-mini-latest"                       | codex-mini-latest                  |
+      | model = "gpt-4.5-preview"                        | gpt-4.5-preview                    |
+      | model: gpt-4-32k                                  | gpt-4-32k                          |
+      | model = "gpt-4o-audio-preview-2024-10-01"        | gpt-4o-audio-preview-2024-10-01    |
+      | model: gpt-4o-realtime-preview-2024-10-01         | gpt-4o-realtime-preview-2024-10-01 |
+      | model = "chatgpt-4o-latest"                       | chatgpt-4o-latest                  |
+      | model: text-moderation                            | text-moderation                    |
+      | model = "gpt-3.5-turbo-instruct"                 | gpt-3.5-turbo-instruct             |
+      | model = "gpt-3.5-turbo-16k-0613"                 | gpt-3.5-turbo-16k-0613             |
+      | model = "gpt-3.5-turbo-16k"                      | gpt-3.5-turbo-16k                  |
+      | model = "gpt-4-0314"                             | gpt-4-0314                         |
+      | model = "gpt-4-1106-preview"                     | gpt-4-1106-preview                 |
+      | model = "gpt-4-0125-preview"                     | gpt-4-0125-preview                 |
+      | model = "gpt-4-1106-vision-preview"              | gpt-4-1106-vision-preview          |
+      | model = "gpt-4-32k-0314"                         | gpt-4-32k-0314                     |
+      | model = "gpt-4-32k-0613"                         | gpt-4-32k-0613                     |
+      | model = "gpt-4-vision-preview"                   | gpt-4-vision-preview               |
+      | model = "gpt-4-turbo-preview-completions"        | gpt-4-turbo-preview-completions    |
+      | model = "gpt-4o-mini-audio-preview"              | gpt-4o-mini-audio-preview          |
+      | model = "gpt-4o-mini-realtime-preview"           | gpt-4o-mini-realtime-preview       |
+      | model = "dall-e-2"                               | dall-e-2                           |
+      | model = "dall-e-3"                               | dall-e-3                           |
+      | model = "sora-2"                                  | sora-2                             |
+      | model = "sora-2-pro"                             | sora-2-pro                         |
+      | model = "sora-2-2025-10-06"                      | sora-2-2025-10-06                  |
+      | model = "sora-2-pro-2025-10-06"                  | sora-2-pro-2025-10-06              |
+      | model = "text-davinci-003"                       | text-davinci-003                   |
+      | model = "text-ada-001"                           | text-ada-001                       |
+      | model = "text-curie-001"                         | text-curie-001                     |
+      | model = "text-davinci-edit-001"                  | text-davinci-edit-001              |
+      | model = "text-moderation-007"                    | text-moderation-007                |
+      | model = "text-moderation-latest"                 | text-moderation-latest             |
+      | model = "text-moderation-stable"                 | text-moderation-stable             |
+      | model = "code-davinci-002"                       | code-davinci-002                   |
+      | model = "code-cushman-001"                       | code-cushman-001                   |
+      | model = "code-davinci-edit-001"                  | code-davinci-edit-001              |
+      | model = "code-search-ada-code-001"               | code-search-ada-code-001           |
+      | model = "code-search-babbage-text-001"           | code-search-babbage-text-001       |
+      | model = "text-search-ada-doc-001"                | text-search-ada-doc-001            |
+      | model = "text-search-davinci-query-001"          | text-search-davinci-query-001      |
+      | model = "text-similarity-babbage-001"            | text-similarity-babbage-001        |
+      | model = "text-similarity-davinci-001"            | text-similarity-davinci-001        |
+
+  Scenario Outline: Detect legacy OpenAI base models (require context)
+    Given a line containing "<line>"
+    When I scan the line for matches
+    Then I should find model "<model>" from provider "openai"
+    And the match type should be "llm"
+
+    Examples:
+      | line                    | model        |
+      | model = "ada"           | ada          |
+      | model = "babbage"       | babbage      |
+      | model = "babbage-002"   | babbage-002  |
+      | model = "curie"         | curie        |
+      | model = "davinci"       | davinci      |
+      | model = "davinci-002"   | davinci-002  |
 
   Scenario Outline: Detect models with date suffixes
     Given a line containing "<line>"
@@ -142,6 +194,9 @@ Feature: LLM model pattern detection
       | model = "gemini-live"                                    | gemini-live                                     |
       | model = "imagen-3.0-generate-002"                       | imagen-3.0-generate-002                         |
       | model: veo-3.0-fast-generate-preview                    | veo-3.0-fast-generate-preview                   |
+      | model = "gemini-3-pro-preview"                          | gemini-3-pro-preview                            |
+      | model: gemini-robotics-er-1.5-preview                   | gemini-robotics-er-1.5-preview                  |
+      | model = "gemini-robotics-er-1.6-preview"                | gemini-robotics-er-1.6-preview                  |
 
   Scenario Outline: No false positives on overlapping patterns
     Given a line containing "<line>"


### PR DESCRIPTION
## Summary

- Corrige la couverture des patterns regex suite aux PRs de mise à jour du registre (#36-#39) dont le step `claude-validation` n'avait pas traité tous les cas
- **Anthropic** : `claude-opus-4` et `claude-sonnet-4` avec suffixe date 8 chiffres (`-20250514`)
- **Google** : `gemini-3-pro-preview` et variantes `gemini-robotics-er`
- **OpenAI** : GPT-4 versionnés MMDD, vision, turbo-completions, GPT-4o-mini audio/realtime, DALL-E 2/3, Sora 2, GPT-3.5 instruct/16k, tous les modèles legacy text/code/search/similarity
- **Faux positifs** : `ada`, `babbage`, `curie`, `davinci` protégés par `context_required` + lookbehind `(?<![a-z0-9-])` pour éviter de matcher dans les noms composés comme `text-embedding-ada-002`

## Test plan

- [x] `validate_patterns` : 149 modèles couverts, 0 non couverts (était 56)
- [x] 340 tests passent (`pytest tests/`)
- [x] `ruff check` et `ruff format` : aucune erreur
- [x] `mypy --strict` : aucune erreur

Generated with [Claude Code](https://claude.com/claude-code)