### PR TITLE
ci: update pre-commit hooks to latest versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,17 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files
       - id: check-json
-      - id: check-merge-conflicts
+      - id: check-merge-conflict
       - id: detect-private-key
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.6
+    rev: v0.15.10
     hooks:
       - id: ruff
         args: [--fix]

--- a/tests/features/patterns.feature
+++ b/tests/features/patterns.feature
@@ -236,4 +236,3 @@ Feature: LLM model pattern detection
     Given a line containing "Hello world, this is a normal line of code"
     When I scan the line for matches
     Then I should find 0 matches
-


### PR DESCRIPTION
## Summary

- `pre-commit-hooks` v4.6.0 → v6.0.0
- Renomme `check-merge-conflicts` → `check-merge-conflict` (hook renommé depuis v5+)
- `ruff-pre-commit` v0.8.6 → v0.15.10

## Test plan

- [x] `pre-commit run --all-files` : tous les hooks passent

Generated with [Claude Code](https://claude.com/claude-code)