### PR TITLE
fix: bug substring _issue_exists + alignement doc/code

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,17 +265,17 @@ Cette section concerne les mainteneurs du repo `tracking-llm-discontinued`.
 | Source | Description |
 |---|---|
 | `data/registry.json` | Registre JSON des modèles dépréciés, commité dans le dépôt |
-| [deprecations.info](https://deprecations.info/) | Flux en direct fusionné dans le registre aux deux semaines via GitHub Actions |
+| [deprecations.info](https://deprecations.info/) | Flux en direct fusionné dans le registre deux fois par mois (le 1er et le 15) via GitHub Actions |
 
 Le pipeline de scan lit uniquement le fichier JSON local — aucun appel réseau lors du scan.
 
 ### Mise à jour du registre
 
-Le registre est mis à jour automatiquement aux deux semaines (lundi à 06:00 UTC) par `.github/workflows/update-registry.yml`.
+Le registre est mis à jour automatiquement deux fois par mois (le 1er et le 15 à 06:00 UTC) par `.github/workflows/update-registry.yml`.
 
 ```mermaid
 flowchart TD
-    A[Cron lundi 06h UTC<br>semaines paires] --> B[Fetch deprecations.info]
+    A[Cron le 1er et 15<br>du mois 06h UTC] --> B[Fetch deprecations.info]
     B --> C{Flux<br>accessible?}
     C -->|Non| D[Créer issue<br>d'échec]
     C -->|Oui| E[Fusionner avec<br>registry.json]

--- a/docs/one-pager.md
+++ b/docs/one-pager.md
@@ -12,7 +12,7 @@ Les projets de Baseline utilisent des modeles LLM (OpenAI, Anthropic, Google) qu
 | F2 | Detecter les modeles de 3 fournisseurs (OpenAI, Anthropic, Google) et les embeddings (OpenAI, Voyage) | Implemente |
 | F3 | Comparer les modeles detectes au registre de depreciation JSON (`data/registry.json`) | Implemente |
 | F4 | Gerer les suffixes de date (ex: `gpt-4o-2024-08-06` -> `gpt-4o`) | Implemente |
-| F5 | Creer automatiquement des issues GitHub avec fichiers affectes et remplacement suggere | Implemente |
+| F5 | Creer automatiquement des issues GitHub avec fichiers affectes et remplacement suggere | Partiel (issues + fichiers OK ; remplacement suggere : a faire, mapping deprecated -> remplacement non implemente dans `issue_reporter._build_body`) |
 | F6 | Eviter les doublons d'issues (verification avant creation) | Implemente |
 | F7 | Alimenter le registre depuis le flux live deprecations.info | Implemente |
 | F8 | Mettre a jour le registre automatiquement toutes les 2 semaines via PR | Implemente |

--- a/src/issue_reporter.py
+++ b/src/issue_reporter.py
@@ -192,8 +192,10 @@ def _issue_exists(model: str) -> bool:
         logger.warning("Failed to parse issue list response: %s", result.stdout[:200])
         return False
 
-    # Verify model name is actually in the title (GitHub search can be fuzzy)
-    return any(model in str(issue.get("title", "")) for issue in issues)
+    # Verify the title matches exactly: a substring check would falsely match
+    # e.g. "gpt-4" against an open issue titled "Modèle déprécié : gpt-4o".
+    expected_title = _build_title_for_model(model)
+    return any(str(issue.get("title", "")) == expected_title for issue in issues)
 
 
 def _create_issue(
@@ -235,9 +237,14 @@ def _create_issue(
     return None
 
 
+def _build_title_for_model(model: str) -> str:
+    """Build the issue title from a model name."""
+    return f"Modèle déprécié : {model}"
+
+
 def _build_title(lifecycle: DeprecatedModel) -> str:
     """Build the issue title."""
-    return f"Modèle déprécié : {lifecycle.model}"
+    return _build_title_for_model(lifecycle.model)
 
 
 def _build_body(

--- a/tests/features/scanner.feature
+++ b/tests/features/scanner.feature
@@ -50,3 +50,15 @@ Feature: Repository file scanner
     Given a non-existent scan path
     When I scan the directory for repo "test-repo"
     Then I should find 0 scan matches
+
+  Scenario: Scanner picks up files matched by name (Dockerfile, Makefile, .env)
+    Given a temporary directory with the following files:
+      | path        | content              |
+      | Dockerfile  | ENV MODEL=gpt-4o     |
+      | Makefile    | model: claude-3-opus |
+      | .env        | MODEL=gpt-4-turbo    |
+    When I scan the directory for repo "test-repo"
+    Then I should find 3 scan matches
+    And the results should contain model "gpt-4o"
+    And the results should contain model "claude-3-opus"
+    And the results should contain model "gpt-4-turbo"

--- a/tests/features/update_registry.feature
+++ b/tests/features/update_registry.feature
@@ -45,3 +45,9 @@ Feature: Mise a jour du registre depuis le flux deprecations.info
     And a feed with duplicate model "gpt-4o"
     When I run the registry update
     Then the registry should contain "gpt-4o" with status "shutdown"
+
+  Scenario: update_readme retourne False si le fichier est introuvable
+    Given a README path that does not exist
+    And a registry with 2 models
+    When I call update_readme
+    Then update_readme should return False

--- a/tests/test_issue_reporter.py
+++ b/tests/test_issue_reporter.py
@@ -13,6 +13,7 @@ from src.issue_reporter import (
     DeprecationAlert,
     _build_body,
     _build_title,
+    _issue_exists,
     _validate_assignees,
     create_issues,
 )
@@ -280,3 +281,72 @@ def check_webhook_called(create_result: dict[str, object], count: int) -> None:
     assert webhook_mock.call_count == count, (
         f"Expected webhook called {count} time(s), got {webhook_mock.call_count}"
     )
+
+
+# --- Unit tests for _issue_exists (regression for substring false-positive bug) ---
+
+
+def _gh_list_issues(titles: list[str]) -> subprocess.CompletedProcess[str]:
+    """Build a gh CLI 'issue list --json' response with the given titles."""
+    payload = [{"number": i + 1, "title": t} for i, t in enumerate(titles)]
+    import json as _json
+
+    return subprocess.CompletedProcess(
+        args=[], returncode=0, stdout=_json.dumps(payload), stderr=""
+    )
+
+
+def test_issue_exists_returns_true_on_exact_title_match() -> None:
+    """When an open issue exactly matches the model title, _issue_exists is True."""
+    fake = _gh_list_issues(["Modèle déprécié : gpt-4"])
+    with patch("src.issue_reporter.subprocess.run", return_value=fake):
+        assert _issue_exists("gpt-4") is True
+
+
+def test_issue_exists_returns_false_when_only_superstring_match() -> None:
+    """A title for 'gpt-4o' must NOT count as an existing issue for 'gpt-4'.
+
+    Regression: previously the check used substring matching, which falsely
+    blocked creating issues for 'gpt-4' when an open 'gpt-4o' issue existed.
+    """
+    fake = _gh_list_issues(["Modèle déprécié : gpt-4o"])
+    with patch("src.issue_reporter.subprocess.run", return_value=fake):
+        assert _issue_exists("gpt-4") is False
+
+
+def test_issue_exists_returns_false_when_title_is_substring() -> None:
+    """A 'gpt-4o-mini' lookup must NOT match a 'gpt-4o' open issue."""
+    fake = _gh_list_issues(["Modèle déprécié : gpt-4o"])
+    with patch("src.issue_reporter.subprocess.run", return_value=fake):
+        assert _issue_exists("gpt-4o-mini") is False
+
+
+def test_issue_exists_returns_false_for_unsafe_model_name() -> None:
+    """Model names with unsafe chars are rejected without calling gh."""
+    with patch("src.issue_reporter.subprocess.run") as mock_run:
+        assert _issue_exists("gpt-4; rm -rf /") is False
+        mock_run.assert_not_called()
+
+
+def test_issue_exists_returns_false_on_gh_failure() -> None:
+    """When gh CLI returns non-zero, treat as 'no existing issue' (proceed)."""
+    fail = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="auth failed")
+    with patch("src.issue_reporter.subprocess.run", return_value=fail):
+        assert _issue_exists("gpt-4") is False
+
+
+def test_issue_exists_returns_false_on_invalid_json() -> None:
+    """Malformed gh CLI output is handled without raising."""
+    bad = subprocess.CompletedProcess(args=[], returncode=0, stdout="not-json", stderr="")
+    with patch("src.issue_reporter.subprocess.run", return_value=bad):
+        assert _issue_exists("gpt-4") is False
+
+
+def test_issue_exists_returns_false_on_timeout() -> None:
+    """Gh CLI timeout is handled and returns False (proceed with creation)."""
+
+    def raise_timeout(*args: object, **kwargs: object) -> None:
+        raise subprocess.TimeoutExpired(cmd=["gh"], timeout=30)
+
+    with patch("src.issue_reporter.subprocess.run", side_effect=raise_timeout):
+        assert _issue_exists("gpt-4") is False

--- a/tests/test_update_registry.py
+++ b/tests/test_update_registry.py
@@ -108,6 +108,12 @@ def given_readme_without_markers(readme_path: Path) -> Path:
     return readme_path
 
 
+@given("a README path that does not exist")
+def given_readme_missing(readme_path: Path) -> None:
+    """No-op: readme_path fixture returns a path with no file at it."""
+    assert not readme_path.exists()
+
+
 @given(
     parsers.cfparse('a feed with duplicate model "{model}"'),
     target_fixture="mock_feed",


### PR DESCRIPTION
## Summary

- **Bug critique** : `_issue_exists` faisait un substring match (`model in title`). Pour `model='gpt-4'` avec une issue ouverte titrée `Modèle déprécié : gpt-4o`, la check retournait `True` à tort, bloquant la création d'issues légitimes pour `gpt-4`. Remplacé par un match exact via `_build_title_for_model`.
- **Tests ajoutés** (+9) : 7 unitaires sur `_issue_exists` (regression bug + branches d'erreur : timeout, JSON invalide, gh failure, nom unsafe), 1 scénario BDD scanner (Dockerfile/Makefile/.env), 1 scénario BDD update_readme sur fichier inexistant.
- **Doc-align** : corrige le drift cron dans le README (le workflow tourne le 1er et 15 du mois à 06:00 UTC, pas "lundi sur semaines paires") en 3 endroits incluant le diagramme Mermaid. One-pager F5 (remplacement suggéré) passe de "Implemente" à "Partiel" avec note décrivant la dette.

## Test plan

- [x] `pytest tests/` : 408 tests verts (était 399)
- [x] `ruff check src/ tests/` clean
- [x] `ruff format --check` clean
- [x] `pre-commit run --all-files` clean
- [x] Coverage : 87% → 88%
- [x] Test de régression `test_issue_exists_returns_false_when_only_superstring_match` confirmé passant après fix et failant sur l'ancien code

Generated with [Claude Code](https://claude.com/claude-code)