### PR TITLE
feat: balayage mensuel de l'organisation pour la derive des modeles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,12 @@ jobs:
         with:
           python-version: "3.12"
 
+      # Version identique a celle epinglee dans .pre-commit-config.yaml.
+      # Sans cet alignement, la CI et le hook local se contredisent des qu'une
+      # regle change entre versions : un fichier accepte en local est refuse
+      # en CI, et la correction de l'un casse l'autre.
       - name: Install ruff
-        run: pip install ruff
+        run: pip install ruff==0.15.10
 
       - name: Ruff check
         run: ruff check src/

--- a/.github/workflows/org-sweep.yml
+++ b/.github/workflows/org-sweep.yml
@@ -1,0 +1,69 @@
+# Balayage mensuel de toute l'organisation.
+#
+# Complement indispensable au ruleset de Baseline-quebec/.github, qui impose le
+# scan sur les pull requests. Une regle de ruleset n'ecoute que pull_request et
+# merge_group : elle attrape un modele deprecie qu'on INTRODUIT, jamais un
+# modele qui DEVIENT deprecie alors que le code n'a pas bouge. Ce cas n'ouvre
+# aucune pull request, donc seul un balayage planifie le detecte.
+#
+# Prerequis : le secret ORG_SWEEP_TOKEN, un jeton avec les droits de lecture sur
+# les depots de l'organisation et d'ecriture sur les issues. Le jeton par defaut
+# de GitHub Actions est limite a ce depot-ci et ne peut ni cloner les autres
+# depots prives ni y creer d'issue.
+#
+# Les variables Jira sont optionnelles : sans elles le balayage tourne et ouvre
+# quand meme les issues GitHub, seul le ticket consolide est saute.
+
+name: Balayage mensuel de l'organisation
+
+on:
+  schedule:
+    - cron: "0 7 1 * *" # Le 1er de chaque mois a 07:00 UTC, apres la mise a jour du registre
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: "Analyser sans creer d'issue ni de ticket"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: org-sweep
+  cancel-in-progress: false
+
+jobs:
+  balayage:
+    name: Balayer les depots de l'organisation
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Balayer
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+          GH_TOKEN: ${{ secrets.ORG_SWEEP_TOKEN }}
+          JIRA_BASE_URL: ${{ vars.JIRA_BASE_URL }}
+          JIRA_EMAIL: ${{ vars.JIRA_EMAIL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+          JIRA_PROJECT_KEY: ${{ vars.JIRA_PROJECT_KEY }}
+          ASSIGNEES: ${{ vars.LLM_SCAN_ASSIGNEES || '' }}
+          DRY_RUN: ${{ inputs.dry-run && '--dry-run' || '' }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error title=Jeton manquant::Le secret ORG_SWEEP_TOKEN est requis pour lire les depots de l'organisation."
+            exit 1
+          fi
+          python -m src.org_sweep \
+            --org Baseline-quebec \
+            --assignees "$ASSIGNEES" \
+            --exclude tracking-llm-discontinued \
+            --summary-out "$GITHUB_STEP_SUMMARY" \
+            ${DRY_RUN}

--- a/README.md
+++ b/README.md
@@ -216,7 +216,37 @@ flowchart TD
 
 ---
 
+## Deux mécanismes complémentaires
+
+Le scan couvre deux risques différents, et un seul mécanisme ne peut pas couvrir les deux.
+
+| Risque | Mécanisme | Déclencheur |
+|---|---|---|
+| Un modèle déprécié est **introduit** dans le code | Ruleset organisationnel appelant `Baseline-quebec/.github` | Pull request, merge queue |
+| Un modèle **devient** déprécié alors que le code n'a pas bougé | `org-sweep.yml` de ce dépôt | Cron mensuel |
+
+La distinction est la raison d'être du balayage. Quand un fournisseur déprécie un modèle, le registre change mais votre code ne change pas : aucune pull request n'est ouverte, donc aucune règle de ruleset ne se déclenche. C'est pourtant le scénario le plus fréquent, et celui qui vous laisse en production sur un modèle qui va s'arrêter.
+
+### Balayage mensuel de l'organisation
+
+`org-sweep.yml` tourne le 1er de chaque mois, une heure après la mise à jour du registre. Il liste les dépôts de l'organisation, les clone en surface dans un répertoire temporaire, les scanne contre le registre courant, ouvre une issue dans **le dépôt concerné**, et dépose un ticket Jira consolidé.
+
+Un seul ticket Jira pour tout le balayage, pas un par dépôt : quarante tickets en priorité Highest le même matin sont indiscernables du bruit, et la première chose qu'on fait avec du bruit est de le couper.
+
+**Prérequis :** le secret `ORG_SWEEP_TOKEN`, un jeton avec lecture sur les dépôts de l'organisation et écriture sur les issues. Le `GITHUB_TOKEN` par défaut est limité à ce dépôt-ci et ne peut ni cloner les autres dépôts privés ni y créer d'issue. Sous SSO SAML, le jeton doit en plus être explicitement autorisé pour l'organisation, sinon la liste des dépôts revient **vide sans erreur** et le balayage se termine en vert sans rien avoir scanné. Le code refuse ce cas et fait échouer la run.
+
+**Jira, optionnel :** sans les variables `JIRA_BASE_URL`, `JIRA_EMAIL`, `JIRA_PROJECT_KEY` et le secret `JIRA_API_TOKEN`, le balayage tourne et ouvre quand même les issues GitHub ; seul le ticket est sauté.
+
+```bash
+# Essai à blanc, sans créer d'issue ni de ticket
+gh workflow run org-sweep.yml -f dry-run=true
+```
+
+---
+
 ## Utiliser l'action dans votre dépôt
+
+> **Note :** depuis la mise en place du ruleset organisationnel, il n'y a plus rien à copier dans les dépôts de `Baseline-quebec`. Le workflow central est imposé automatiquement. Cette section reste valable pour un dépôt hors organisation.
 
 ### Ajouter le workflow
 

--- a/src/deprecation_feed.py
+++ b/src/deprecation_feed.py
@@ -40,7 +40,9 @@ def fetch_deprecations() -> list[DeprecatedModel]:
     """
     for attempt in range(1, MAX_RETRIES + 1):
         try:
-            req = urllib.request.Request(FEED_URL, headers={"User-Agent": "llm-scanner/1.0"})  # noqa: S310
+            req = urllib.request.Request(  # noqa: S310 - FEED_URL is a hardcoded https constant
+                FEED_URL, headers={"User-Agent": "llm-scanner/1.0"}
+            )
             with urllib.request.urlopen(req, timeout=FEED_TIMEOUT) as resp:  # noqa: S310
                 data: list[dict[str, Any]] = json.loads(resp.read().decode())
             return _parse_feed(data)

--- a/src/issue_reporter.py
+++ b/src/issue_reporter.py
@@ -44,11 +44,17 @@ def create_issues(
     dry_run: bool = False,
     webhook_url: str | None = None,
     repo_name: str = "",
+    target_repo: str | None = None,
 ) -> tuple[int, int]:
     """Create GitHub issues for deprecated models.
 
     Groups alerts by model so each model gets at most one issue.
     Skips creation if an open issue already exists for the model.
+
+    `target_repo` routes every gh call to an explicit repository, which the
+    organisation-wide sweep needs since it scans clones rather than the
+    checkout it runs from. Left as None, gh infers the repository from the
+    working directory, which is the behaviour the per-repo action relies on.
 
     Returns (issues_created, issues_failed).
     """
@@ -59,7 +65,7 @@ def create_issues(
     valid_assignees = _validate_assignees(assignees) if assignees else None
 
     if not dry_run:
-        _ensure_label()
+        _ensure_label(target_repo)
 
     by_model: dict[str, list[DeprecationAlert]] = {}
     for alert in alerts:
@@ -68,7 +74,7 @@ def create_issues(
     created = 0
     failed = 0
     for model, model_alerts in by_model.items():
-        if not dry_run and _issue_exists(model):
+        if not dry_run and _issue_exists(model, target_repo):
             logger.info("Open issue already exists for %s, skipping", model)
             continue
 
@@ -93,7 +99,7 @@ def create_issues(
             created += 1
             continue
 
-        issue_url = _create_issue(title, body, valid_assignees)
+        issue_url = _create_issue(title, body, valid_assignees, target_repo)
         if issue_url:
             created += 1
             if webhook_url:
@@ -122,7 +128,12 @@ def _validate_assignees(assignees: list[str]) -> list[str] | None:
     return valid or None
 
 
-def _ensure_label() -> None:
+def _repo_flag(target_repo: str | None) -> list[str]:
+    """Build the gh --repo flag, or nothing when the current directory decides."""
+    return ["--repo", target_repo] if target_repo else []
+
+
+def _ensure_label(target_repo: str | None = None) -> None:
     """Create the deprecated-model label if it doesn't exist."""
     try:
         result = subprocess.run(
@@ -136,6 +147,7 @@ def _ensure_label() -> None:
                 "--color",
                 "D93F0B",
                 "--force",
+                *_repo_flag(target_repo),
             ],
             capture_output=True,
             text=True,
@@ -149,7 +161,7 @@ def _ensure_label() -> None:
         logger.warning("Could not create label '%s': %s", ISSUE_LABEL, result.stderr)
 
 
-def _issue_exists(model: str) -> bool:
+def _issue_exists(model: str, target_repo: str | None = None) -> bool:
     """Check if an open issue already exists for this model.
 
     Uses GitHub search to find candidates, then verifies the model name
@@ -173,6 +185,7 @@ def _issue_exists(model: str) -> bool:
                 "open",
                 "--json",
                 "number,title",
+                *_repo_flag(target_repo),
             ],
             capture_output=True,
             text=True,
@@ -202,6 +215,7 @@ def _create_issue(
     title: str,
     body: str,
     assignees: list[str] | None = None,
+    target_repo: str | None = None,
 ) -> str | None:
     """Create a single GitHub issue. Returns the issue URL on success, None on failure."""
     cmd = [
@@ -214,6 +228,7 @@ def _create_issue(
         body,
         "--label",
         ISSUE_LABEL,
+        *_repo_flag(target_repo),
     ]
     if assignees:
         cmd.extend(["--assignee", ",".join(assignees)])

--- a/src/jira.py
+++ b/src/jira.py
@@ -78,7 +78,10 @@ def _request(
     )
     try:
         with urllib.request.urlopen(request, timeout=TIMEOUT_SECONDS) as response:  # noqa: S310
-            return json.loads(response.read().decode())
+            # json.loads est typé Any : on refuse explicitement une réponse qui
+            # ne serait pas un objet JSON plutôt que de la laisser passer.
+            body = json.loads(response.read().decode())
+            return body if isinstance(body, dict) else None
     except urllib.error.HTTPError as exc:
         detail = exc.read().decode(errors="replace")[:300]
         logger.warning("Jira %s returned HTTP %s: %s", path, exc.code, detail)

--- a/src/jira.py
+++ b/src/jira.py
@@ -1,0 +1,155 @@
+"""Jira ticket creation for the organisation-wide sweep.
+
+One consolidated ticket per sweep, not one per repository: forty tickets at
+Highest priority in a single morning is indistinguishable from noise, and the
+first thing anyone does with noise is mute it.
+
+Entirely optional. When the Jira environment variables are absent the sweep
+still runs and still opens GitHub issues; only the ticket is skipped. This keeps
+the sweep usable before Jira credentials are provisioned.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+
+
+logger = logging.getLogger(__name__)
+
+TIMEOUT_SECONDS = 30
+LABEL = "modeles-deprecies"
+PRIORITY = "Highest"
+
+
+@dataclass(frozen=True)
+class JiraConfig:
+    """Credentials and target project, read from the environment."""
+
+    base_url: str
+    email: str
+    api_token: str
+    project_key: str
+
+    @classmethod
+    def from_env(cls) -> JiraConfig | None:
+        """Build the configuration, or None when Jira is not configured."""
+        values = {
+            "base_url": os.environ.get("JIRA_BASE_URL", "").rstrip("/"),
+            "email": os.environ.get("JIRA_EMAIL", ""),
+            "api_token": os.environ.get("JIRA_API_TOKEN", ""),
+            "project_key": os.environ.get("JIRA_PROJECT_KEY", ""),
+        }
+        missing = [name for name, value in values.items() if not value]
+        if missing:
+            logger.info("Jira not configured (missing %s), skipping ticket", ", ".join(missing))
+            return None
+        return cls(**values)
+
+    @property
+    def auth_header(self) -> str:
+        """Return the Basic authentication header Jira Cloud expects."""
+        raw = f"{self.email}:{self.api_token}".encode()
+        return "Basic " + base64.b64encode(raw).decode()
+
+
+def _request(
+    config: JiraConfig,
+    path: str,
+    payload: dict[str, object] | None = None,
+) -> dict[str, object] | None:
+    """Call the Jira REST API. Returns the parsed body, or None on failure."""
+    url = f"{config.base_url}{path}"
+    data = json.dumps(payload).encode() if payload is not None else None
+    request = urllib.request.Request(  # noqa: S310 - base_url comes from our own config
+        url,
+        data=data,
+        method="POST" if data else "GET",
+        headers={
+            "Authorization": config.auth_header,
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=TIMEOUT_SECONDS) as response:  # noqa: S310
+            return json.loads(response.read().decode())
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode(errors="replace")[:300]
+        logger.warning("Jira %s returned HTTP %s: %s", path, exc.code, detail)
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+        logger.warning("Jira %s failed: %s", path, exc)
+    return None
+
+
+def open_ticket_exists(config: JiraConfig) -> bool:
+    """True when an unresolved sweep ticket is already open.
+
+    Without this check the monthly cron files a fresh Highest-priority ticket
+    every month for the same unmigrated model, and the backlog fills with
+    duplicates of a problem already tracked.
+    """
+    jql = f'project = "{config.project_key}" AND labels = "{LABEL}" AND statusCategory != Done'
+    body = _request(config, "/rest/api/3/search/jql", {"jql": jql, "maxResults": 1, "fields": []})
+    if body is None:
+        return False
+    issues = body.get("issues")
+    return bool(isinstance(issues, list) and issues)
+
+
+def _document(summary_markdown: str) -> dict[str, object]:
+    """Wrap the summary in the Atlassian Document Format Jira expects."""
+    paragraphs = [line for line in summary_markdown.splitlines() if line.strip()]
+    return {
+        "type": "doc",
+        "version": 1,
+        "content": [
+            {"type": "paragraph", "content": [{"type": "text", "text": line}]}
+            for line in paragraphs
+        ],
+    }
+
+
+def create_ticket(summary_markdown: str, affected_repositories: int) -> str | None:
+    """File the consolidated ticket. Returns the issue key, or None."""
+    config = JiraConfig.from_env()
+    if config is None:
+        return None
+
+    if open_ticket_exists(config):
+        logger.info("A sweep ticket is already open, skipping creation")
+        return None
+
+    title = (
+        f"Modèles LLM dépréciés référencés dans {affected_repositories} dépôt(s) de l'organisation"
+    )
+    fields: dict[str, object] = {
+        "project": {"key": config.project_key},
+        "summary": title,
+        "description": _document(summary_markdown),
+        "issuetype": {"name": "Task"},
+        "labels": [LABEL],
+        "priority": {"name": PRIORITY},
+    }
+
+    body = _request(config, "/rest/api/3/issue", {"fields": fields})
+    if body is None:
+        # Team-managed projects often have no priority field at all, and Jira
+        # rejects the whole request rather than ignoring the unknown field.
+        # Retrying without it is better than losing the ticket entirely.
+        logger.info("Retrying Jira ticket creation without the priority field")
+        fields.pop("priority")
+        body = _request(config, "/rest/api/3/issue", {"fields": fields})
+
+    if body is None:
+        logger.error("Could not create the Jira ticket")
+        return None
+
+    key = str(body.get("key", ""))
+    logger.info("Created Jira ticket %s", key)
+    return key or None

--- a/src/org_sweep.py
+++ b/src/org_sweep.py
@@ -1,0 +1,301 @@
+"""Organisation-wide sweep for deprecated model references.
+
+The per-repository action only runs on pull requests, so it catches a deprecated
+model being *introduced*. It can never catch drift: when a provider deprecates a
+model, the registry changes but the repository code does not, no pull request is
+opened, and nothing runs. This sweep closes that gap by cloning every repository
+in the organisation on a schedule and scanning it against the current registry.
+
+Repositories are cloned shallow into a temporary directory and deleted right
+after scanning, so nothing persists on the runner.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from src.deprecations import check_deprecation
+from src.issue_reporter import DeprecationAlert, create_issues
+from src.jira import create_ticket
+from src.scanner import scan_directory
+
+
+logger = logging.getLogger(__name__)
+
+GH_TIMEOUT_SECONDS = 60
+CLONE_TIMEOUT_SECONDS = 300
+REPO_LIST_LIMIT = 500
+
+
+@dataclass(frozen=True)
+class Repository:
+    """A repository to sweep."""
+
+    name_with_owner: str
+
+    @property
+    def name(self) -> str:
+        """Return the repository name without its owner."""
+        return self.name_with_owner.split("/")[-1]
+
+
+@dataclass
+class SweepResult:
+    """Outcome of sweeping a single repository."""
+
+    repository: str
+    scanned: bool = False
+    deprecated_models: list[str] = field(default_factory=list)
+    issues_created: int = 0
+    error: str = ""
+
+
+def list_repositories(org: str, excluded: set[str] | None = None) -> list[Repository]:
+    """List the organisation's non-archived, non-fork repositories.
+
+    Archived repositories are excluded on purpose: they cannot receive issues,
+    and a deprecated model in code nobody runs is not actionable.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "gh",
+                "repo",
+                "list",
+                org,
+                "--limit",
+                str(REPO_LIST_LIMIT),
+                "--no-archived",
+                "--source",
+                "--json",
+                "nameWithOwner,isArchived,hasIssuesEnabled",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=GH_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        logger.error("Timeout listing repositories for %s", org)
+        return []
+
+    if result.returncode != 0:
+        logger.error("Failed to list repositories: %s", result.stderr.strip())
+        return []
+
+    try:
+        payload: list[dict[str, object]] = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        logger.error("Could not parse repository list: %s", result.stdout[:200])
+        return []
+
+    excluded = excluded or set()
+    repositories: list[Repository] = []
+    for entry in payload:
+        name = str(entry.get("nameWithOwner", ""))
+        if not name or name in excluded or name.split("/")[-1] in excluded:
+            continue
+        # A repository with issues disabled cannot be alerted; skipping it here
+        # avoids a guaranteed failure later and keeps the run green for a
+        # condition that is a repository setting, not a code problem.
+        if entry.get("hasIssuesEnabled") is False:
+            logger.warning("Issues disabled on %s, skipping", name)
+            continue
+        repositories.append(Repository(name_with_owner=name))
+    return repositories
+
+
+def clone(repository: Repository, destination: Path) -> bool:
+    """Shallow-clone a repository. Returns True on success."""
+    try:
+        result = subprocess.run(
+            [
+                "gh",
+                "repo",
+                "clone",
+                repository.name_with_owner,
+                str(destination),
+                "--",
+                "--depth",
+                "1",
+                "--single-branch",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=CLONE_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        logger.warning("Timeout cloning %s", repository.name_with_owner)
+        return False
+    if result.returncode != 0:
+        logger.warning("Failed to clone %s: %s", repository.name_with_owner, result.stderr.strip())
+        return False
+    return True
+
+
+def sweep_repository(
+    repository: Repository,
+    *,
+    assignees: list[str] | None,
+    dry_run: bool,
+) -> SweepResult:
+    """Clone, scan and alert a single repository."""
+    outcome = SweepResult(repository=repository.name_with_owner)
+
+    with tempfile.TemporaryDirectory(prefix="sweep-") as workspace:
+        destination = Path(workspace) / repository.name
+        if not clone(repository, destination):
+            outcome.error = "clone failed"
+            return outcome
+
+        scan = scan_directory(destination, repository.name_with_owner)
+        outcome.scanned = True
+
+        alerts = [
+            DeprecationAlert(match=match, lifecycle=lifecycle)
+            for match in scan.matches
+            if (lifecycle := check_deprecation(match.model)) is not None
+        ]
+        outcome.deprecated_models = sorted({alert.lifecycle.model for alert in alerts})
+
+        if not alerts:
+            return outcome
+
+        created, failed = create_issues(
+            alerts,
+            assignees=assignees,
+            dry_run=dry_run,
+            repo_name=repository.name_with_owner,
+            target_repo=repository.name_with_owner,
+        )
+        outcome.issues_created = created
+        if failed:
+            outcome.error = f"{failed} issue(s) could not be created"
+
+    return outcome
+
+
+def sweep(
+    org: str,
+    *,
+    assignees: list[str] | None = None,
+    dry_run: bool = False,
+    excluded: set[str] | None = None,
+) -> list[SweepResult]:
+    """Sweep every repository of the organisation."""
+    repositories = list_repositories(org, excluded)
+    logger.info("Sweeping %d repositories in %s", len(repositories), org)
+
+    results: list[SweepResult] = []
+    for index, repository in enumerate(repositories, start=1):
+        logger.info("[%d/%d] %s", index, len(repositories), repository.name_with_owner)
+        results.append(sweep_repository(repository, assignees=assignees, dry_run=dry_run))
+    return results
+
+
+def build_summary(results: list[SweepResult]) -> str:
+    """Build the Markdown summary written to the job output."""
+    affected = [r for r in results if r.deprecated_models]
+    failed = [r for r in results if r.error]
+
+    lines = [
+        "## Balayage mensuel des modèles dépréciés",
+        "",
+        f"- Dépôts analysés : **{sum(1 for r in results if r.scanned)}** sur {len(results)}",
+        f"- Dépôts touchés : **{len(affected)}**",
+        f"- Issues créées : **{sum(r.issues_created for r in results)}**",
+        "",
+    ]
+
+    if affected:
+        lines += [
+            "### Dépôts touchés",
+            "",
+            "| Dépôt | Modèles dépréciés | Issues |",
+            "|---|---|---|",
+        ]
+        lines += [
+            f"| `{r.repository}` | {', '.join(r.deprecated_models)} | {r.issues_created} |"
+            for r in sorted(affected, key=lambda r: r.repository)
+        ]
+        lines.append("")
+
+    if failed:
+        lines += ["### Dépôts non analysés", "", "| Dépôt | Raison |", "|---|---|"]
+        lines += [
+            f"| `{r.repository}` | {r.error} |" for r in sorted(failed, key=lambda r: r.repository)
+        ]
+        lines.append("")
+
+    if not affected:
+        lines.append("Aucun modèle déprécié référencé dans l'organisation.")
+
+    return "\n".join(lines)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--org", required=True, help="GitHub organisation to sweep")
+    parser.add_argument("--assignees", default="", help="Comma-separated GitHub usernames")
+    parser.add_argument(
+        "--exclude",
+        default="",
+        help="Comma-separated repositories to skip, by name or owner/name",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Scan only, do not create issues")
+    parser.add_argument("--summary-out", type=Path, help="Write the Markdown summary to this file")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Sweep the organisation and report. Always returns 0."""
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    args = parse_args(argv)
+
+    assignees = [a.strip() for a in args.assignees.split(",") if a.strip()] or None
+    excluded = {e.strip() for e in args.exclude.split(",") if e.strip()}
+
+    results = sweep(args.org, assignees=assignees, dry_run=args.dry_run, excluded=excluded)
+
+    # An organisation with zero repositories is not a clean sweep, it is a
+    # broken one. The usual cause is a token that is valid but not authorised
+    # for the organisation under SAML single sign-on: the GraphQL listing then
+    # returns an empty array instead of an error, and the run would otherwise
+    # end green having scanned nothing at all.
+    if not results:
+        logger.error(
+            "::error title=Aucun depot::Aucun depot listable dans %s. "
+            "Verifier que le jeton est autorise pour l'organisation (SSO SAML).",
+            args.org,
+        )
+        return 1
+
+    summary = build_summary(results)
+
+    print(summary)
+    if args.summary_out:
+        args.summary_out.write_text(summary + "\n", encoding="utf-8")
+
+    affected = [r for r in results if r.deprecated_models]
+    if affected and not args.dry_run:
+        create_ticket(summary, len(affected))
+
+    # A failed clone is reported but never fails the run: one unreachable
+    # repository must not hide the results of the eighty-one others.
+    for result in results:
+        if result.error:
+            logger.warning("%s: %s", result.repository, result.error)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/features/org_sweep.feature
+++ b/tests/features/org_sweep.feature
@@ -1,0 +1,60 @@
+Feature: Organisation-wide sweep for deprecated models
+  The per-repository action only runs on pull requests, so it catches a
+  deprecated model being introduced. It cannot catch drift: when a provider
+  deprecates a model, the registry changes but the repository code does not,
+  no pull request is opened, and nothing runs. The monthly sweep clones every
+  repository in the organisation and scans it against the current registry.
+
+  Scenario: Archived repositories are excluded from the sweep
+    Given the organisation lists an active repository and an archived repository
+    When I list the repositories to sweep
+    Then only the active repository should be listed
+
+  Scenario: Repositories with issues disabled are skipped
+    Given the organisation lists a repository with issues disabled
+    When I list the repositories to sweep
+    Then no repository should be listed
+
+  Scenario: Explicitly excluded repositories are skipped
+    Given the organisation lists repositories "org/alpha" and "org/beta"
+    When I list the repositories excluding "beta"
+    Then only "org/alpha" should be listed
+
+  Scenario: A failed repository listing returns nothing rather than crashing
+    Given the repository listing command fails
+    When I list the repositories to sweep
+    Then no repository should be listed
+
+  Scenario: Issues are created in the scanned repository, not the runner repository
+    Given a repository referencing a deprecated model
+    When I sweep that repository
+    Then the issue should be created in that repository
+    And one issue should be reported as created
+
+  Scenario: A repository that cannot be cloned does not stop the sweep
+    Given a repository that cannot be cloned
+    When I sweep that repository
+    Then the result should report a clone failure
+    And the repository should not be marked as scanned
+
+  Scenario: A clean repository produces no issue
+    Given a repository referencing only supported models
+    When I sweep that repository
+    Then no issue should be created
+    And the repository should be marked as scanned
+
+  Scenario: The summary lists affected repositories
+    Given sweep results with one affected repository and one failure
+    When I build the summary
+    Then the summary should name the affected repository
+    And the summary should name the failed repository
+
+  Scenario: A clean organisation says so explicitly
+    Given sweep results with no affected repository
+    When I build the summary
+    Then the summary should state that no deprecated model was found
+
+  Scenario: An empty repository listing fails the run instead of passing green
+    Given no repository can be listed
+    When I run the sweep
+    Then the run should fail

--- a/tests/test_org_sweep.py
+++ b/tests/test_org_sweep.py
@@ -1,0 +1,240 @@
+"""BDD step definitions for the organisation-wide sweep."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pytest_bdd import given, parsers, scenarios, then, when
+
+from src.org_sweep import (
+    Repository,
+    SweepResult,
+    build_summary,
+    list_repositories,
+    main,
+    sweep_repository,
+)
+
+
+scenarios("features/org_sweep.feature")
+
+
+def _gh_output(payload: list[dict[str, Any]], returncode: int = 0) -> MagicMock:
+    process = MagicMock(spec=subprocess.CompletedProcess)
+    process.returncode = returncode
+    process.stdout = json.dumps(payload)
+    process.stderr = ""
+    return process
+
+
+@pytest.fixture
+def context() -> dict[str, Any]:
+    return {}
+
+
+@given("the organisation lists an active repository and an archived repository")
+def _active_and_archived(context: dict[str, Any]) -> None:
+    # gh --no-archived filters server-side, so the archived entry never comes
+    # back. The listing must not reintroduce it from a stale local assumption.
+    context["listing"] = _gh_output(
+        [{"nameWithOwner": "org/active", "isArchived": False, "hasIssuesEnabled": True}]
+    )
+
+
+@given("the organisation lists a repository with issues disabled")
+def _issues_disabled(context: dict[str, Any]) -> None:
+    context["listing"] = _gh_output(
+        [{"nameWithOwner": "org/sans-issues", "isArchived": False, "hasIssuesEnabled": False}]
+    )
+
+
+@given(parsers.parse('the organisation lists repositories "{first}" and "{second}"'))
+def _two_repositories(context: dict[str, Any], first: str, second: str) -> None:
+    context["listing"] = _gh_output(
+        [
+            {"nameWithOwner": first, "isArchived": False, "hasIssuesEnabled": True},
+            {"nameWithOwner": second, "isArchived": False, "hasIssuesEnabled": True},
+        ]
+    )
+
+
+@given("the repository listing command fails")
+def _listing_fails(context: dict[str, Any]) -> None:
+    process = MagicMock(spec=subprocess.CompletedProcess)
+    process.returncode = 1
+    process.stdout = ""
+    process.stderr = "HTTP 403"
+    context["listing"] = process
+
+
+@when("I list the repositories to sweep")
+def _list_repositories(context: dict[str, Any]) -> None:
+    with patch("src.org_sweep.subprocess.run", return_value=context["listing"]):
+        context["repositories"] = list_repositories("org")
+
+
+@when(parsers.parse('I list the repositories excluding "{excluded}"'))
+def _list_excluding(context: dict[str, Any], excluded: str) -> None:
+    with patch("src.org_sweep.subprocess.run", return_value=context["listing"]):
+        context["repositories"] = list_repositories("org", {excluded})
+
+
+@then("only the active repository should be listed")
+def _only_active(context: dict[str, Any]) -> None:
+    assert [r.name_with_owner for r in context["repositories"]] == ["org/active"]
+
+
+@then("no repository should be listed")
+def _none_listed(context: dict[str, Any]) -> None:
+    assert context["repositories"] == []
+
+
+@then(parsers.parse('only "{expected}" should be listed'))
+def _only_expected(context: dict[str, Any], expected: str) -> None:
+    assert [r.name_with_owner for r in context["repositories"]] == [expected]
+
+
+def _clone_writing(content: str) -> Any:
+    """Simulate gh repo clone by writing a file into the destination."""
+
+    def _clone(repository: Repository, destination: Path) -> bool:
+        destination.mkdir(parents=True, exist_ok=True)
+        (destination / "config.py").write_text(content, encoding="utf-8")
+        return True
+
+    return _clone
+
+
+@given("a repository referencing a deprecated model")
+def _repository_with_deprecated(context: dict[str, Any]) -> None:
+    context["clone"] = _clone_writing('MODEL = "claude-3-sonnet-20240229"\n')
+    context["repository"] = Repository(name_with_owner="org/projet")
+
+
+@given("a repository referencing only supported models")
+def _repository_clean(context: dict[str, Any]) -> None:
+    context["clone"] = _clone_writing("TIMEOUT = 30\n")
+    context["repository"] = Repository(name_with_owner="org/propre")
+
+
+@given("a repository that cannot be cloned")
+def _repository_unclonable(context: dict[str, Any]) -> None:
+    context["clone"] = lambda repository, destination: False
+    context["repository"] = Repository(name_with_owner="org/prive")
+
+
+@when("I sweep that repository")
+def _sweep(context: dict[str, Any]) -> None:
+    with (
+        patch("src.org_sweep.clone", side_effect=context["clone"]),
+        patch("src.org_sweep.create_issues", return_value=(1, 0)) as create_issues,
+        patch("src.org_sweep.check_deprecation") as check,
+    ):
+        check.side_effect = lambda model: (
+            MagicMock(model=model) if "claude-3-sonnet" in model else None
+        )
+        context["result"] = sweep_repository(context["repository"], assignees=None, dry_run=False)
+        context["create_issues"] = create_issues
+
+
+@then("the issue should be created in that repository")
+def _issue_targets_repository(context: dict[str, Any]) -> None:
+    """The sweep scans clones, so gh must be told which repository to file in.
+
+    Without an explicit target, gh infers the repository from the working
+    directory and every alert lands in the sweeper's own repository.
+    """
+    _, kwargs = context["create_issues"].call_args
+    assert kwargs["target_repo"] == "org/projet"
+
+
+@then("one issue should be reported as created")
+def _one_issue(context: dict[str, Any]) -> None:
+    assert context["result"].issues_created == 1
+
+
+@then("no issue should be created")
+def _no_issue(context: dict[str, Any]) -> None:
+    assert context["result"].issues_created == 0
+    context["create_issues"].assert_not_called()
+
+
+@then("the result should report a clone failure")
+def _clone_failure(context: dict[str, Any]) -> None:
+    assert context["result"].error == "clone failed"
+
+
+@then("the repository should not be marked as scanned")
+def _not_scanned(context: dict[str, Any]) -> None:
+    assert context["result"].scanned is False
+
+
+@then("the repository should be marked as scanned")
+def _scanned(context: dict[str, Any]) -> None:
+    assert context["result"].scanned is True
+
+
+@given("sweep results with one affected repository and one failure")
+def _mixed_results(context: dict[str, Any]) -> None:
+    context["results"] = [
+        SweepResult(
+            repository="org/touche",
+            scanned=True,
+            deprecated_models=["claude-3-sonnet-20240229"],
+            issues_created=1,
+        ),
+        SweepResult(repository="org/injoignable", scanned=False, error="clone failed"),
+    ]
+
+
+@given("sweep results with no affected repository")
+def _clean_results(context: dict[str, Any]) -> None:
+    context["results"] = [SweepResult(repository="org/propre", scanned=True)]
+
+
+@when("I build the summary")
+def _build(context: dict[str, Any]) -> None:
+    context["summary"] = build_summary(context["results"])
+
+
+@then("the summary should name the affected repository")
+def _summary_names_affected(context: dict[str, Any]) -> None:
+    assert "org/touche" in context["summary"]
+    assert "claude-3-sonnet-20240229" in context["summary"]
+
+
+@then("the summary should name the failed repository")
+def _summary_names_failed(context: dict[str, Any]) -> None:
+    assert "org/injoignable" in context["summary"]
+    assert "clone failed" in context["summary"]
+
+
+@given("no repository can be listed")
+def _no_repository_listable(context: dict[str, Any]) -> None:
+    """The usual cause is a token not authorised for the organisation.
+
+    Under SAML single sign-on the GraphQL listing returns an empty array
+    instead of an error, so the sweep would scan nothing and still succeed.
+    """
+    context["repositories"] = []
+
+
+@when("I run the sweep")
+def _run_main(context: dict[str, Any]) -> None:
+    with patch("src.org_sweep.list_repositories", return_value=context["repositories"]):
+        context["exit_code"] = main(["--org", "org"])
+
+
+@then("the run should fail")
+def _run_failed(context: dict[str, Any]) -> None:
+    assert context["exit_code"] == 1
+
+
+@then("the summary should state that no deprecated model was found")
+def _summary_clean(context: dict[str, Any]) -> None:
+    assert "Aucun modèle déprécié" in context["summary"]


### PR DESCRIPTION
Complete le ruleset organisationnel, qui ne couvre que l'introduction d'un modele deprecie en pull request. La derive, un modele qui devient deprecie sans que le code bouge, n'ouvre aucune PR et echappait completement au scan.

- `org_sweep.py` : liste, clone en surface, scanne, ouvre une issue dans le depot concerne
- `jira.py` : un ticket consolide en priorite Highest, optionnel et idempotent
- `issue_reporter` : depot cible explicite (sans lui les alertes atterrissaient dans le depot du balayeur)
- Une liste de depots vide fait echouer la run plutot que de passer en vert : sous SSO SAML un jeton non autorise retourne une liste vide sans erreur

10 scenarios BDD ajoutes, 418 tests passent.

Note : le `# noqa` dans deprecation_feed.py est sans rapport, une version plus recente de ruff installee par le hook pre-commit signale desormais cette ligne preexistante.

🤖 Generated with [Claude Code](https://claude.com/claude-code)