### PR TITLE
feat: authentifier le balayage par une GitHub App

### DIFF
--- a/.github/workflows/org-sweep.yml
+++ b/.github/workflows/org-sweep.yml
@@ -6,10 +6,16 @@
 # modele qui DEVIENT deprecie alors que le code n'a pas bouge. Ce cas n'ouvre
 # aucune pull request, donc seul un balayage planifie le detecte.
 #
-# Prerequis : le secret ORG_SWEEP_TOKEN, un jeton avec les droits de lecture sur
-# les depots de l'organisation et d'ecriture sur les issues. Le jeton par defaut
-# de GitHub Actions est limite a ce depot-ci et ne peut ni cloner les autres
-# depots prives ni y creer d'issue.
+# Prerequis : une GitHub App installee sur l'organisation, dont l'identifiant
+# et la cle privee sont les secrets ORG_SWEEP_APP_ID et ORG_SWEEP_APP_KEY.
+# Permissions requises, cote depot uniquement : Contents en lecture pour cloner,
+# Issues en ecriture pour alerter. Le jeton par defaut de GitHub Actions est
+# limite a ce depot-ci et ne peut ni cloner les autres depots prives ni y creer
+# d'issue.
+#
+# Une App plutot qu'un jeton personnel : le balayage ne depend d'aucune personne,
+# ne casse pas quand quelqu'un quitte l'equipe, et n'a pas d'expiration a
+# renouveler tous les ans.
 #
 # Les variables Windmill sont optionnelles : sans elles le balayage tourne et
 # ouvre quand meme les issues GitHub, seul le rapport Slack est saute. Le
@@ -47,10 +53,18 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Obtenir un jeton d'installation
+        id: jeton
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.ORG_SWEEP_APP_ID }}
+          private-key: ${{ secrets.ORG_SWEEP_APP_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Balayer
         env:
           PYTHONPATH: ${{ github.workspace }}
-          GH_TOKEN: ${{ secrets.ORG_SWEEP_TOKEN }}
+          GH_TOKEN: ${{ steps.jeton.outputs.token }}
           WINDMILL_WEBHOOK_URL: ${{ vars.WINDMILL_RAPPORT_CONFORMITE_URL }}
           WINDMILL_TOKEN: ${{ secrets.WINDMILL_TOKEN }}
           ASSIGNEES: ${{ vars.LLM_SCAN_ASSIGNEES || '' }}
@@ -58,7 +72,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ -z "${GH_TOKEN:-}" ]; then
-            echo "::error title=Jeton manquant::Le secret ORG_SWEEP_TOKEN est requis pour lire les depots de l'organisation."
+            echo "::error title=Jeton manquant::Les secrets ORG_SWEEP_APP_ID et ORG_SWEEP_APP_KEY sont requis."
             exit 1
           fi
           python -m src.org_sweep \

--- a/README.md
+++ b/README.md
@@ -233,7 +233,17 @@ La distinction est la raison d'être du balayage. Quand un fournisseur dépréci
 
 Un seul message Slack pour tout le balayage, pas un par dépôt : quarante notifications le même matin sont indiscernables du bruit, et la première chose qu'on fait avec du bruit est de le couper. Le message part même quand rien n'est trouvé, parce qu'un canal silencieux est ambigu : on ne sait pas si le balayage a tourné ou s'il est cassé.
 
-**Prérequis :** le secret `ORG_SWEEP_TOKEN`, un jeton avec lecture sur les dépôts de l'organisation et écriture sur les issues. Le `GITHUB_TOKEN` par défaut est limité à ce dépôt-ci et ne peut ni cloner les autres dépôts privés ni y créer d'issue. Sous SSO SAML, le jeton doit en plus être explicitement autorisé pour l'organisation, sinon la liste des dépôts revient **vide sans erreur** et le balayage se termine en vert sans rien avoir scanné. Le code refuse ce cas et fait échouer la run.
+**Prérequis :** une GitHub App installée sur l'organisation, dont l'identifiant et la clé privée sont les secrets `ORG_SWEEP_APP_ID` et `ORG_SWEEP_APP_KEY`. Permissions requises, côté dépôt uniquement :
+
+| Permission | Niveau | Pourquoi |
+|---|---|---|
+| Contents | Lecture | Cloner chaque dépôt pour le scanner |
+| Issues | Lecture et écriture | Ouvrir l'alerte, et vérifier qu'elle n'existe pas déjà |
+| Metadata | Lecture | Accordée automatiquement, non désactivable |
+
+Une App plutôt qu'un jeton personnel : le balayage ne dépend d'aucune personne, ne casse pas quand quelqu'un quitte l'équipe, et n'a pas d'expiration à renouveler chaque année.
+
+La liste des dépôts vient de `/installation/repositories` et non de `gh repo list` : un jeton d'installation ne peut pas énumérer une organisation via GraphQL. L'endpoint retourne exactement ce que l'App a le droit de toucher, ce qui est aussi la définition honnête du périmètre du balayage. Si la liste revient vide, le code fait échouer la run plutôt que de se terminer en vert sans avoir rien scanné.
 
 **Slack, optionnel :** le formatage du rapport vit dans `baseline-automation`, la où se trouvent déjà le jeton Slack et les conventions de rapport de l'équipe. Ce dépôt ne fait qu'envoyer le résultat structuré au script Windmill qui le poste. Sans la variable `WINDMILL_RAPPORT_CONFORMITE_URL` et le secret `WINDMILL_TOKEN`, le balayage tourne et ouvre quand même les issues GitHub ; seul le message est sauté.
 

--- a/src/org_sweep.py
+++ b/src/org_sweep.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 
 GH_TIMEOUT_SECONDS = 60
 CLONE_TIMEOUT_SECONDS = 300
-REPO_LIST_LIMIT = 500
+REPO_PAGE_SIZE = 100
 
 
 @dataclass(frozen=True)
@@ -58,24 +58,25 @@ class SweepResult:
 
 
 def list_repositories(org: str, excluded: set[str] | None = None) -> list[Repository]:
-    """List the organisation's non-archived, non-fork repositories.
+    """List the repositories the GitHub App installation can reach.
 
-    Archived repositories are excluded on purpose: they cannot receive issues,
-    and a deprecated model in code nobody runs is not actionable.
+    Deliberately not `gh repo list`: that command queries GraphQL as a user, and
+    a GitHub App installation token cannot enumerate an organisation that way.
+    The installation endpoint returns exactly what the App was granted, which is
+    also the honest definition of what this sweep is allowed to touch.
+
+    Archived repositories are dropped on purpose: they cannot receive issues, and
+    a deprecated model in code nobody runs is not actionable.
     """
     try:
         result = subprocess.run(
             [
                 "gh",
-                "repo",
-                "list",
-                org,
-                "--limit",
-                str(REPO_LIST_LIMIT),
-                "--no-archived",
-                "--source",
-                "--json",
-                "nameWithOwner,isArchived,hasIssuesEnabled",
+                "api",
+                "--paginate",
+                f"/installation/repositories?per_page={REPO_PAGE_SIZE}",
+                "--jq",
+                ".repositories[] | {full_name, archived, has_issues}",
             ],
             capture_output=True,
             text=True,
@@ -90,22 +91,26 @@ def list_repositories(org: str, excluded: set[str] | None = None) -> list[Reposi
         logger.error("Failed to list repositories: %s", result.stderr.strip())
         return []
 
-    try:
-        payload: list[dict[str, object]] = json.loads(result.stdout)
-    except json.JSONDecodeError:
-        logger.error("Could not parse repository list: %s", result.stdout[:200])
-        return []
-
     excluded = excluded or set()
     repositories: list[Repository] = []
-    for entry in payload:
-        name = str(entry.get("nameWithOwner", ""))
+    for ligne in result.stdout.splitlines():
+        if not ligne.strip():
+            continue
+        try:
+            entry: dict[str, object] = json.loads(ligne)
+        except json.JSONDecodeError:
+            logger.warning("Could not parse repository entry: %s", ligne[:120])
+            continue
+
+        name = str(entry.get("full_name", ""))
         if not name or name in excluded or name.split("/")[-1] in excluded:
+            continue
+        if entry.get("archived") is True:
             continue
         # A repository with issues disabled cannot be alerted; skipping it here
         # avoids a guaranteed failure later and keeps the run green for a
         # condition that is a repository setting, not a code problem.
-        if entry.get("hasIssuesEnabled") is False:
+        if entry.get("has_issues") is False:
             logger.warning("Issues disabled on %s, skipping", name)
             continue
         repositories.append(Repository(name_with_owner=name))

--- a/tests/features/slack_report.feature
+++ b/tests/features/slack_report.feature
@@ -1,0 +1,43 @@
+Feature: Consolidated sweep report sent to Slack
+  The monthly sweep ships its structured result to a Windmill webhook, which
+  formats it and posts it to Slack. Formatting lives in baseline-automation, so
+  this module only has to ship the data and never break the sweep when Slack or
+  Windmill is unreachable.
+
+  Scenario: The report is skipped when Windmill is not configured
+    Given Windmill is not configured
+    When I send the report
+    Then no HTTP request should have been made
+    And the result should be False
+
+  Scenario: A partial configuration is treated as no configuration
+    Given only the Windmill URL is configured
+    When I send the report
+    Then no HTTP request should have been made
+    And the result should be False
+
+  Scenario: The payload carries the report type and the affected repositories
+    Given Windmill is configured
+    When I send the report for 2 affected repositories out of 82
+    Then the payload should declare the report type "modeles"
+    And the payload should list 2 repositories
+    And the payload should declare 82 scanned repositories
+    And the request should carry the Windmill token
+
+  Scenario: An empty report is still sent
+    Given Windmill is configured
+    When I send the report for 0 affected repositories out of 82
+    Then the request should have been made
+    And the payload should list 0 repositories
+
+  Scenario: An HTTP error never breaks the sweep
+    Given Windmill is configured
+    And Windmill returns HTTP 500
+    When I send the report
+    Then the result should be False
+
+  Scenario: An unreachable Windmill never breaks the sweep
+    Given Windmill is configured
+    And Windmill is unreachable
+    When I send the report
+    Then the result should be False

--- a/tests/test_org_sweep.py
+++ b/tests/test_org_sweep.py
@@ -25,9 +25,10 @@ scenarios("features/org_sweep.feature")
 
 
 def _gh_output(payload: list[dict[str, Any]], returncode: int = 0) -> MagicMock:
+    """Mimic `gh api --jq`, which emits one JSON object per line."""
     process = MagicMock(spec=subprocess.CompletedProcess)
     process.returncode = returncode
-    process.stdout = json.dumps(payload)
+    process.stdout = "\n".join(json.dumps(entry) for entry in payload)
     process.stderr = ""
     return process
 
@@ -39,17 +40,21 @@ def context() -> dict[str, Any]:
 
 @given("the organisation lists an active repository and an archived repository")
 def _active_and_archived(context: dict[str, Any]) -> None:
-    # gh --no-archived filters server-side, so the archived entry never comes
-    # back. The listing must not reintroduce it from a stale local assumption.
+    # The installation endpoint returns archived repositories too, unlike
+    # `gh repo list --no-archived`. Filtering is now ours to do, and forgetting
+    # it would file issues on repositories nobody can act on.
     context["listing"] = _gh_output(
-        [{"nameWithOwner": "org/active", "isArchived": False, "hasIssuesEnabled": True}]
+        [
+            {"full_name": "org/active", "archived": False, "has_issues": True},
+            {"full_name": "org/archive", "archived": True, "has_issues": True},
+        ]
     )
 
 
 @given("the organisation lists a repository with issues disabled")
 def _issues_disabled(context: dict[str, Any]) -> None:
     context["listing"] = _gh_output(
-        [{"nameWithOwner": "org/sans-issues", "isArchived": False, "hasIssuesEnabled": False}]
+        [{"full_name": "org/sans-issues", "archived": False, "has_issues": False}]
     )
 
 
@@ -57,8 +62,8 @@ def _issues_disabled(context: dict[str, Any]) -> None:
 def _two_repositories(context: dict[str, Any], first: str, second: str) -> None:
     context["listing"] = _gh_output(
         [
-            {"nameWithOwner": first, "isArchived": False, "hasIssuesEnabled": True},
-            {"nameWithOwner": second, "isArchived": False, "hasIssuesEnabled": True},
+            {"full_name": first, "archived": False, "has_issues": True},
+            {"full_name": second, "archived": False, "has_issues": True},
         ]
     )
 

--- a/tests/test_slack_report.py
+++ b/tests/test_slack_report.py
@@ -1,0 +1,127 @@
+"""BDD step definitions for the consolidated Slack report."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock, patch
+from urllib.error import HTTPError, URLError
+
+import pytest
+from pytest_bdd import given, parsers, scenarios, then, when
+
+from src.slack_report import send_report
+
+
+scenarios("features/slack_report.feature")
+
+URL = "https://app.windmill.dev/api/r/baseline/conformite/rapport"
+TOKEN = "jeton-de-test"  # noqa: S105 - valeur factice de test, aucun secret reel
+
+
+@pytest.fixture
+def context() -> dict[str, Any]:
+    return {}
+
+
+@given("Windmill is not configured")
+def _not_configured(context: dict[str, Any], monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("WINDMILL_WEBHOOK_URL", raising=False)
+    monkeypatch.delenv("WINDMILL_TOKEN", raising=False)
+
+
+@given("only the Windmill URL is configured")
+def _partially_configured(context: dict[str, Any], monkeypatch: pytest.MonkeyPatch) -> None:
+    """A half-configured webhook must behave like no webhook at all.
+
+    Sending an unauthenticated request would fail anyway, but silently: the
+    sweep would look like it reported when it did not.
+    """
+    monkeypatch.setenv("WINDMILL_WEBHOOK_URL", URL)
+    monkeypatch.delenv("WINDMILL_TOKEN", raising=False)
+
+
+@given("Windmill is configured")
+def _configured(context: dict[str, Any], monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("WINDMILL_WEBHOOK_URL", URL)
+    monkeypatch.setenv("WINDMILL_TOKEN", TOKEN)
+    context["erreur"] = None
+
+
+@given("Windmill returns HTTP 500")
+def _http_error(context: dict[str, Any]) -> None:
+    context["erreur"] = HTTPError(URL, 500, "Server Error", {}, None)  # type: ignore[arg-type]
+
+
+@given("Windmill is unreachable")
+def _unreachable(context: dict[str, Any]) -> None:
+    context["erreur"] = URLError("connexion refusee")
+
+
+def _envoyer(context: dict[str, Any], affected: int, scanned: int) -> None:
+    reponse = MagicMock()
+    reponse.status = 200
+    reponse.__enter__ = MagicMock(return_value=reponse)
+    reponse.__exit__ = MagicMock(return_value=False)
+
+    with patch("src.slack_report.urllib.request.urlopen") as ouvrir:
+        if context.get("erreur") is not None:
+            ouvrir.side_effect = context["erreur"]
+        else:
+            ouvrir.return_value = reponse
+        context["resultat"] = send_report(
+            [{"depot": f"org/depot-{i}", "elements": [f"modele-{i}"]} for i in range(affected)],
+            scanned,
+        )
+        context["appels"] = ouvrir
+
+
+@when("I send the report")
+def _send(context: dict[str, Any]) -> None:
+    _envoyer(context, affected=1, scanned=82)
+
+
+@when(parsers.parse("I send the report for {affected:d} affected repositories out of {scanned:d}"))
+def _send_counts(context: dict[str, Any], affected: int, scanned: int) -> None:
+    _envoyer(context, affected=affected, scanned=scanned)
+
+
+def _charge(context: dict[str, Any]) -> dict[str, Any]:
+    requete = context["appels"].call_args.args[0]
+    return json.loads(requete.data.decode())
+
+
+@then("no HTTP request should have been made")
+def _no_request(context: dict[str, Any]) -> None:
+    context["appels"].assert_not_called()
+
+
+@then("the request should have been made")
+def _request_made(context: dict[str, Any]) -> None:
+    context["appels"].assert_called_once()
+
+
+@then("the result should be False")
+def _false(context: dict[str, Any]) -> None:
+    assert context["resultat"] is False
+
+
+@then(parsers.parse('the payload should declare the report type "{attendu}"'))
+def _type(context: dict[str, Any], attendu: str) -> None:
+    assert _charge(context)["type_rapport"] == attendu
+
+
+@then(parsers.parse("the payload should list {attendu:d} repositories"))
+def _liste(context: dict[str, Any], attendu: int) -> None:
+    assert len(_charge(context)["depots"]) == attendu
+
+
+@then(parsers.parse("the payload should declare {attendu:d} scanned repositories"))
+def _scannes(context: dict[str, Any], attendu: int) -> None:
+    assert _charge(context)["total_analyses"] == attendu
+
+
+@then("the request should carry the Windmill token")
+def _jeton(context: dict[str, Any]) -> None:
+    requete = context["appels"].call_args.args[0]
+    assert requete.get_header("Authorization") == f"Bearer {TOKEN}"


### PR DESCRIPTION
Remplace le jeton personnel par une GitHub App : le balayage ne depend plus d'une personne et n'a pas d'expiration annuelle.

Changement de code necessaire : un jeton d'installation ne peut pas enumerer une organisation via GraphQL, donc `gh repo list` ne fonctionne plus. La liste vient de `/installation/repositories`, qui inclut les depots archives, desormais filtres cote code.

Permissions requises : Contents en lecture pour cloner, Issues en lecture et ecriture pour alerter.

Ajoute aussi 6 scenarios pour `slack_report`, qui n'avait aucun test alors qu'il tourne une fois par mois.

🤖 Generated with [Claude Code](https://claude.com/claude-code)