### PR TITLE
fix: dedupliquer en essai a blanc, et reparer le webhook CRM

### DIFF
--- a/.github/workflows/org-sweep.yml
+++ b/.github/workflows/org-sweep.yml
@@ -6,10 +6,16 @@
 # modele qui DEVIENT deprecie alors que le code n'a pas bouge. Ce cas n'ouvre
 # aucune pull request, donc seul un balayage planifie le detecte.
 #
-# Prerequis : le secret ORG_SWEEP_TOKEN, un jeton avec les droits de lecture sur
-# les depots de l'organisation et d'ecriture sur les issues. Le jeton par defaut
-# de GitHub Actions est limite a ce depot-ci et ne peut ni cloner les autres
-# depots prives ni y creer d'issue.
+# Prerequis : une GitHub App installee sur l'organisation, dont l'identifiant
+# et la cle privee sont les secrets ORG_SWEEP_APP_ID et ORG_SWEEP_APP_KEY.
+# Permissions requises, cote depot uniquement : Contents en lecture pour cloner,
+# Issues en ecriture pour alerter. Le jeton par defaut de GitHub Actions est
+# limite a ce depot-ci et ne peut ni cloner les autres depots prives ni y creer
+# d'issue.
+#
+# Une App plutot qu'un jeton personnel : le balayage ne depend d'aucune personne,
+# ne casse pas quand quelqu'un quitte l'equipe, et n'a pas d'expiration a
+# renouveler tous les ans.
 #
 # Les variables Windmill sont optionnelles : sans elles le balayage tourne et
 # ouvre quand meme les issues GitHub, seul le rapport Slack est saute. Le
@@ -47,10 +53,18 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Obtenir un jeton d'installation
+        id: jeton
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.ORG_SWEEP_APP_ID }}
+          private-key: ${{ secrets.ORG_SWEEP_APP_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Balayer
         env:
           PYTHONPATH: ${{ github.workspace }}
-          GH_TOKEN: ${{ secrets.ORG_SWEEP_TOKEN }}
+          GH_TOKEN: ${{ steps.jeton.outputs.token }}
           WINDMILL_WEBHOOK_URL: ${{ vars.WINDMILL_RAPPORT_CONFORMITE_URL }}
           WINDMILL_TOKEN: ${{ secrets.WINDMILL_TOKEN }}
           ASSIGNEES: ${{ vars.LLM_SCAN_ASSIGNEES || '' }}
@@ -58,7 +72,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ -z "${GH_TOKEN:-}" ]; then
-            echo "::error title=Jeton manquant::Le secret ORG_SWEEP_TOKEN est requis pour lire les depots de l'organisation."
+            echo "::error title=Jeton manquant::Les secrets ORG_SWEEP_APP_ID et ORG_SWEEP_APP_KEY sont requis."
             exit 1
           fi
           python -m src.org_sweep \

--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ L'action composite exécutée dans vos repos ne fait aucun appel à une API AI/L
 
 ```mermaid
 flowchart TD
-    A[Création d'un tag<br>ou cron bimensuel] --> B[Checkout du repo]
+    A[Pull request via ruleset<br>ou balayage mensuel] --> B[Checkout du repo]
     B --> C[Action composite<br>tracking-llm-discontinued]
     C --> D[Scan des fichiers<br>patterns.py + scanner.py]
     D --> E{Modèles<br>dépréciés?}
     E -->|Oui| F[Créer issues GitHub<br>avec date d'arrêt]
     F --> H{Webhook<br>configuré?}
-    H -->|Oui| I[POST vers CRM]
+    H -->|Oui| I[POST authentifié<br>vers le CRM]
     H -->|Non| J[Fin]
     E -->|Non| G[Aucune action]
 ```
@@ -285,10 +285,23 @@ jobs:
         with:
           repo-name: ${{ github.repository }}
           assignees: ${{ vars.LLM_SCAN_ASSIGNEES || '' }}
-          webhook-url: ${{ secrets.LLM_SCAN_WEBHOOK_URL }}
+          webhook-url: ${{ vars.LLM_SCAN_WEBHOOK_URL }}
+          webhook-token: ${{ secrets.LLM_SCAN_WEBHOOK_TOKEN }}
 ```
 
-Aucun secret ni variable n'est requis pour les repos consommateurs. L'action utilise le `GITHUB_TOKEN` automatique pour créer les issues. La variable `LLM_SCAN_ASSIGNEES` et le secret `LLM_SCAN_WEBHOOK_URL` sont configurés au niveau de l'organisation.
+Aucun secret ni variable n'est requis pour les repos consommateurs. L'action utilise le `GITHUB_TOKEN` automatique pour créer les issues. `LLM_SCAN_ASSIGNEES`, `LLM_SCAN_WEBHOOK_URL` et `LLM_SCAN_WEBHOOK_TOKEN` sont configurés au niveau de l'organisation.
+
+### L'URL du webhook est une variable, pas un secret
+
+Une destination n'est pas un identifiant. La mettre en secret la rend illisible
+pour tout le monde, y compris pour les propriétaires de l'organisation, et c'est
+exactement ce qui a permis à l'intégration CRM d'échouer en silence : le webhook
+partait à chaque issue et recevait un **403** que personne ne pouvait
+diagnostiquer, faute de pouvoir lire vers quoi il pointait.
+
+L'URL vit donc dans une variable d'organisation, lisible et auditable. Seul le
+jeton reste un secret. Si le récepteur répond 403 alors qu'aucun jeton n'est
+configuré, le journal le dit explicitement au lieu de laisser un code d'erreur nu.
 
 ### Prérequis pour les forks
 
@@ -348,7 +361,8 @@ PYTHONPATH=. python -m src.update_registry
 |---|---|---|
 | `ANTHROPIC_API_KEY` | Repository secret | Clé API Anthropic pour la validation Claude dans le workflow de mise à jour |
 | `LLM_SCAN_ASSIGNEES` | Organization variable | Noms d'utilisateur GitHub assignés aux issues (partagée avec les repos consommateurs) |
-| `LLM_SCAN_WEBHOOK_URL` | Organization secret (optionnel) | URL webhook pour envoyer les détails des issues vers un CRM |
+| `LLM_SCAN_WEBHOOK_URL` | Organization **variable** (optionnel) | URL du récepteur, appelée une fois par issue réellement créée |
+| `LLM_SCAN_WEBHOOK_TOKEN` | Organization secret (optionnel) | Jeton porteur envoyé en `Authorization: Bearer`. Sans lui, une destination protégée répond 403 |
 
 ### Utilisation locale
 

--- a/README.md
+++ b/README.md
@@ -233,7 +233,17 @@ La distinction est la raison d'être du balayage. Quand un fournisseur dépréci
 
 Un seul message Slack pour tout le balayage, pas un par dépôt : quarante notifications le même matin sont indiscernables du bruit, et la première chose qu'on fait avec du bruit est de le couper. Le message part même quand rien n'est trouvé, parce qu'un canal silencieux est ambigu : on ne sait pas si le balayage a tourné ou s'il est cassé.
 
-**Prérequis :** le secret `ORG_SWEEP_TOKEN`, un jeton avec lecture sur les dépôts de l'organisation et écriture sur les issues. Le `GITHUB_TOKEN` par défaut est limité à ce dépôt-ci et ne peut ni cloner les autres dépôts privés ni y créer d'issue. Sous SSO SAML, le jeton doit en plus être explicitement autorisé pour l'organisation, sinon la liste des dépôts revient **vide sans erreur** et le balayage se termine en vert sans rien avoir scanné. Le code refuse ce cas et fait échouer la run.
+**Prérequis :** une GitHub App installée sur l'organisation, dont l'identifiant et la clé privée sont les secrets `ORG_SWEEP_APP_ID` et `ORG_SWEEP_APP_KEY`. Permissions requises, côté dépôt uniquement :
+
+| Permission | Niveau | Pourquoi |
+|---|---|---|
+| Contents | Lecture | Cloner chaque dépôt pour le scanner |
+| Issues | Lecture et écriture | Ouvrir l'alerte, et vérifier qu'elle n'existe pas déjà |
+| Metadata | Lecture | Accordée automatiquement, non désactivable |
+
+Une App plutôt qu'un jeton personnel : le balayage ne dépend d'aucune personne, ne casse pas quand quelqu'un quitte l'équipe, et n'a pas d'expiration à renouveler chaque année.
+
+La liste des dépôts vient de `/installation/repositories` et non de `gh repo list` : un jeton d'installation ne peut pas énumérer une organisation via GraphQL. L'endpoint retourne exactement ce que l'App a le droit de toucher, ce qui est aussi la définition honnête du périmètre du balayage. Si la liste revient vide, le code fait échouer la run plutôt que de se terminer en vert sans avoir rien scanné.
 
 **Slack, optionnel :** le formatage du rapport vit dans `baseline-automation`, la où se trouvent déjà le jeton Slack et les conventions de rapport de l'équipe. Ce dépôt ne fait qu'envoyer le résultat structuré au script Windmill qui le poste. Sans la variable `WINDMILL_RAPPORT_CONFORMITE_URL` et le secret `WINDMILL_TOKEN`, le balayage tourne et ouvre quand même les issues GitHub ; seul le message est sauté.
 

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,15 @@ inputs:
     required: false
     default: "false"
   webhook-url:
-    description: "Optional webhook URL to POST issue details for CRM integration"
+    description: >
+      Optional webhook URL to POST issue details for CRM integration. Pass it
+      from a GitHub variable, not a secret: a destination URL is not a
+      credential, and hiding it is what let the previous integration fail
+      silently with a 403 nobody could diagnose.
+    required: false
+    default: ""
+  webhook-token:
+    description: "Bearer token for the webhook destination. This one is a secret."
     required: false
     default: ""
 
@@ -49,6 +57,7 @@ runs:
         SCAN_ASSIGNEES: ${{ inputs.assignees }}
         SCAN_DRY_RUN: ${{ inputs.dry-run }}
         SCAN_WEBHOOK_URL: ${{ inputs.webhook-url }}
+        LLM_SCAN_WEBHOOK_TOKEN: ${{ inputs.webhook-token }}
         PYTHONPATH: ${{ github.action_path }}
         GH_TOKEN: ${{ github.token }}
       run: |

--- a/src/issue_reporter.py
+++ b/src/issue_reporter.py
@@ -74,7 +74,11 @@ def create_issues(
     created = 0
     failed = 0
     for model, model_alerts in by_model.items():
-        if not dry_run and _issue_exists(model, target_repo):
+        # The existence check runs in dry-run too. It is read-only, and skipping
+        # it made the rehearsal count every alert as new: the estimate came out
+        # far above what a real run would file, which is the opposite of what a
+        # rehearsal is for.
+        if _issue_exists(model, target_repo):
             logger.info("Open issue already exists for %s, skipping", model)
             continue
 

--- a/src/org_sweep.py
+++ b/src/org_sweep.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 
 GH_TIMEOUT_SECONDS = 60
 CLONE_TIMEOUT_SECONDS = 300
-REPO_LIST_LIMIT = 500
+REPO_PAGE_SIZE = 100
 
 
 @dataclass(frozen=True)
@@ -58,24 +58,25 @@ class SweepResult:
 
 
 def list_repositories(org: str, excluded: set[str] | None = None) -> list[Repository]:
-    """List the organisation's non-archived, non-fork repositories.
+    """List the repositories the GitHub App installation can reach.
 
-    Archived repositories are excluded on purpose: they cannot receive issues,
-    and a deprecated model in code nobody runs is not actionable.
+    Deliberately not `gh repo list`: that command queries GraphQL as a user, and
+    a GitHub App installation token cannot enumerate an organisation that way.
+    The installation endpoint returns exactly what the App was granted, which is
+    also the honest definition of what this sweep is allowed to touch.
+
+    Archived repositories are dropped on purpose: they cannot receive issues, and
+    a deprecated model in code nobody runs is not actionable.
     """
     try:
         result = subprocess.run(
             [
                 "gh",
-                "repo",
-                "list",
-                org,
-                "--limit",
-                str(REPO_LIST_LIMIT),
-                "--no-archived",
-                "--source",
-                "--json",
-                "nameWithOwner,isArchived,hasIssuesEnabled",
+                "api",
+                "--paginate",
+                f"/installation/repositories?per_page={REPO_PAGE_SIZE}",
+                "--jq",
+                ".repositories[] | {full_name, archived, has_issues}",
             ],
             capture_output=True,
             text=True,
@@ -90,22 +91,26 @@ def list_repositories(org: str, excluded: set[str] | None = None) -> list[Reposi
         logger.error("Failed to list repositories: %s", result.stderr.strip())
         return []
 
-    try:
-        payload: list[dict[str, object]] = json.loads(result.stdout)
-    except json.JSONDecodeError:
-        logger.error("Could not parse repository list: %s", result.stdout[:200])
-        return []
-
     excluded = excluded or set()
     repositories: list[Repository] = []
-    for entry in payload:
-        name = str(entry.get("nameWithOwner", ""))
+    for ligne in result.stdout.splitlines():
+        if not ligne.strip():
+            continue
+        try:
+            entry: dict[str, object] = json.loads(ligne)
+        except json.JSONDecodeError:
+            logger.warning("Could not parse repository entry: %s", ligne[:120])
+            continue
+
+        name = str(entry.get("full_name", ""))
         if not name or name in excluded or name.split("/")[-1] in excluded:
+            continue
+        if entry.get("archived") is True:
             continue
         # A repository with issues disabled cannot be alerted; skipping it here
         # avoids a guaranteed failure later and keeps the run green for a
         # condition that is a repository setting, not a code problem.
-        if entry.get("hasIssuesEnabled") is False:
+        if entry.get("has_issues") is False:
             logger.warning("Issues disabled on %s, skipping", name)
             continue
         repositories.append(Repository(name_with_owner=name))

--- a/src/webhook.py
+++ b/src/webhook.py
@@ -1,9 +1,20 @@
-"""HTTP webhook notifications for CRM integration."""
+"""HTTP webhook notifications for CRM integration.
+
+The webhook fires once per issue actually created, so the receiver never sees a
+duplicate for a model already tracked: issue creation is deduplicated upstream.
+
+Authentication is a bearer token, kept separate from the URL on purpose. A
+webhook URL is not a secret and belongs in a readable GitHub variable, so anyone
+can audit where alerts are sent; the token is the secret. Storing the URL as a
+secret is what made the previous integration fail silently for months, with a
+403 nobody could diagnose because nobody could read the destination.
+"""
 
 from __future__ import annotations
 
 import json
 import logging
+import os
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 from urllib.error import URLError
@@ -17,6 +28,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _WEBHOOK_TIMEOUT_SECONDS = 10
+_HTTP_FORBIDDEN = 403
 
 
 def send_webhook(
@@ -32,6 +44,10 @@ def send_webhook(
     dry_run: bool = False,
 ) -> bool:
     """Send a webhook notification for a created issue.
+
+    Reads the bearer token from LLM_SCAN_WEBHOOK_TOKEN when present. Without it
+    the request goes out unauthenticated, which any protected endpoint answers
+    with 403.
 
     Returns True on success, False on any error (never raises).
     """
@@ -86,7 +102,12 @@ def _post(url: str, payload: dict[str, object]) -> bool:
     Returns True on success (2xx), False on any error.
     """
     data = json.dumps(payload, ensure_ascii=False).encode("utf-8")
-    request = Request(url, data=data, headers={"Content-Type": "application/json"})  # noqa: S310
+    headers = {"Content-Type": "application/json"}
+    token = os.environ.get("LLM_SCAN_WEBHOOK_TOKEN", "").strip()
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    request = Request(url, data=data, headers=headers)  # noqa: S310
 
     try:
         with urlopen(request, timeout=_WEBHOOK_TIMEOUT_SECONDS) as response:  # noqa: S310
@@ -99,5 +120,12 @@ def _post(url: str, payload: dict[str, object]) -> bool:
         logger.info("Webhook POST to %s succeeded (HTTP %d)", url, status)
         return True
 
-    logger.warning("Webhook POST to %s returned HTTP %d", url, status)
+    if status == _HTTP_FORBIDDEN and not token:
+        logger.warning(
+            "Webhook POST to %s returned HTTP 403 and no token was provided. "
+            "Set LLM_SCAN_WEBHOOK_TOKEN if the destination requires authentication.",
+            url,
+        )
+    else:
+        logger.warning("Webhook POST to %s returned HTTP %d", url, status)
     return False

--- a/tests/features/issue_reporter.feature
+++ b/tests/features/issue_reporter.feature
@@ -29,11 +29,11 @@ Feature: GitHub Issue creation for deprecated models
     And the body should contain "config.py"
     And the body should contain "### Action requise"
 
-  Scenario: Dry run does not call gh CLI
+  Scenario: Dry run reads but never writes
     Given a list of deprecation alerts for models "gpt-4o,gpt-3.5-turbo"
     When I create issues in dry-run mode
     Then 2 issues should be reported as created
-    And gh CLI should not have been called
+    And gh CLI should not have been called to write
 
   Scenario: Issues are grouped by model
     Given a list of deprecation alerts with "gpt-4o" in 3 different files

--- a/tests/features/slack_report.feature
+++ b/tests/features/slack_report.feature
@@ -1,0 +1,43 @@
+Feature: Consolidated sweep report sent to Slack
+  The monthly sweep ships its structured result to a Windmill webhook, which
+  formats it and posts it to Slack. Formatting lives in baseline-automation, so
+  this module only has to ship the data and never break the sweep when Slack or
+  Windmill is unreachable.
+
+  Scenario: The report is skipped when Windmill is not configured
+    Given Windmill is not configured
+    When I send the report
+    Then no HTTP request should have been made
+    And the result should be False
+
+  Scenario: A partial configuration is treated as no configuration
+    Given only the Windmill URL is configured
+    When I send the report
+    Then no HTTP request should have been made
+    And the result should be False
+
+  Scenario: The payload carries the report type and the affected repositories
+    Given Windmill is configured
+    When I send the report for 2 affected repositories out of 82
+    Then the payload should declare the report type "modeles"
+    And the payload should list 2 repositories
+    And the payload should declare 82 scanned repositories
+    And the request should carry the Windmill token
+
+  Scenario: An empty report is still sent
+    Given Windmill is configured
+    When I send the report for 0 affected repositories out of 82
+    Then the request should have been made
+    And the payload should list 0 repositories
+
+  Scenario: An HTTP error never breaks the sweep
+    Given Windmill is configured
+    And Windmill returns HTTP 500
+    When I send the report
+    Then the result should be False
+
+  Scenario: An unreachable Windmill never breaks the sweep
+    Given Windmill is configured
+    And Windmill is unreachable
+    When I send the report
+    Then the result should be False

--- a/tests/features/webhook.feature
+++ b/tests/features/webhook.feature
@@ -42,3 +42,15 @@ Feature: Webhook notifications for CRM integration
     When I send the webhook in dry-run mode
     Then the webhook result should be True
     And no HTTP request should have been made
+
+  Scenario: An authenticated destination receives a bearer token
+    Given a webhook token is configured
+    And a webhook URL that returns HTTP 200
+    When I send the webhook
+    Then the request should carry the bearer token
+
+  Scenario: Without a token the request goes out unauthenticated
+    Given no webhook token is configured
+    And a webhook URL that returns HTTP 200
+    When I send the webhook
+    Then the request should carry no authorization header

--- a/tests/test_issue_reporter.py
+++ b/tests/test_issue_reporter.py
@@ -131,7 +131,12 @@ def build_body(alert: DeprecationAlert) -> str:
 def create_issues_dry_run(alerts: list[DeprecationAlert]) -> dict[str, int | bool]:
     with patch("src.issue_reporter.subprocess.run") as mock_run:
         count, _failed = create_issues(alerts, dry_run=True)
-        return {"count": count, "subprocess_called": mock_run.called}
+        commands = [" ".join(call.args[0]) for call in mock_run.call_args_list]
+        return {
+            "count": count,
+            "subprocess_called": mock_run.called,
+            "wrote": any("issue create" in c or "label create" in c for c in commands),
+        }
 
 
 @when(
@@ -200,12 +205,16 @@ def check_issues_created(create_result: dict[str, int | bool], count: int) -> No
 
 
 @then(
-    "gh CLI should not have been called",
+    "gh CLI should not have been called to write",
 )
-def check_no_subprocess(create_result: dict[str, int | bool]) -> None:
-    assert not create_result["subprocess_called"], (
-        "subprocess.run should not have been called in dry-run"
-    )
+def check_no_write(create_result: dict[str, int | bool]) -> None:
+    """Dry-run must not write, but it may read.
+
+    The deduplication check runs in dry-run on purpose: without it the
+    rehearsal counted every alert as new and overestimated what a real run
+    would file, which defeats the point of rehearsing.
+    """
+    assert not create_result["wrote"], "no issue or label should be created in dry-run"
 
 
 @then(

--- a/tests/test_org_sweep.py
+++ b/tests/test_org_sweep.py
@@ -25,9 +25,10 @@ scenarios("features/org_sweep.feature")
 
 
 def _gh_output(payload: list[dict[str, Any]], returncode: int = 0) -> MagicMock:
+    """Mimic `gh api --jq`, which emits one JSON object per line."""
     process = MagicMock(spec=subprocess.CompletedProcess)
     process.returncode = returncode
-    process.stdout = json.dumps(payload)
+    process.stdout = "\n".join(json.dumps(entry) for entry in payload)
     process.stderr = ""
     return process
 
@@ -39,17 +40,21 @@ def context() -> dict[str, Any]:
 
 @given("the organisation lists an active repository and an archived repository")
 def _active_and_archived(context: dict[str, Any]) -> None:
-    # gh --no-archived filters server-side, so the archived entry never comes
-    # back. The listing must not reintroduce it from a stale local assumption.
+    # The installation endpoint returns archived repositories too, unlike
+    # `gh repo list --no-archived`. Filtering is now ours to do, and forgetting
+    # it would file issues on repositories nobody can act on.
     context["listing"] = _gh_output(
-        [{"nameWithOwner": "org/active", "isArchived": False, "hasIssuesEnabled": True}]
+        [
+            {"full_name": "org/active", "archived": False, "has_issues": True},
+            {"full_name": "org/archive", "archived": True, "has_issues": True},
+        ]
     )
 
 
 @given("the organisation lists a repository with issues disabled")
 def _issues_disabled(context: dict[str, Any]) -> None:
     context["listing"] = _gh_output(
-        [{"nameWithOwner": "org/sans-issues", "isArchived": False, "hasIssuesEnabled": False}]
+        [{"full_name": "org/sans-issues", "archived": False, "has_issues": False}]
     )
 
 
@@ -57,8 +62,8 @@ def _issues_disabled(context: dict[str, Any]) -> None:
 def _two_repositories(context: dict[str, Any], first: str, second: str) -> None:
     context["listing"] = _gh_output(
         [
-            {"nameWithOwner": first, "isArchived": False, "hasIssuesEnabled": True},
-            {"nameWithOwner": second, "isArchived": False, "hasIssuesEnabled": True},
+            {"full_name": first, "archived": False, "has_issues": True},
+            {"full_name": second, "archived": False, "has_issues": True},
         ]
     )
 

--- a/tests/test_slack_report.py
+++ b/tests/test_slack_report.py
@@ -1,0 +1,127 @@
+"""BDD step definitions for the consolidated Slack report."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock, patch
+from urllib.error import HTTPError, URLError
+
+import pytest
+from pytest_bdd import given, parsers, scenarios, then, when
+
+from src.slack_report import send_report
+
+
+scenarios("features/slack_report.feature")
+
+URL = "https://app.windmill.dev/api/r/baseline/conformite/rapport"
+TOKEN = "jeton-de-test"  # noqa: S105 - valeur factice de test, aucun secret reel
+
+
+@pytest.fixture
+def context() -> dict[str, Any]:
+    return {}
+
+
+@given("Windmill is not configured")
+def _not_configured(context: dict[str, Any], monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("WINDMILL_WEBHOOK_URL", raising=False)
+    monkeypatch.delenv("WINDMILL_TOKEN", raising=False)
+
+
+@given("only the Windmill URL is configured")
+def _partially_configured(context: dict[str, Any], monkeypatch: pytest.MonkeyPatch) -> None:
+    """A half-configured webhook must behave like no webhook at all.
+
+    Sending an unauthenticated request would fail anyway, but silently: the
+    sweep would look like it reported when it did not.
+    """
+    monkeypatch.setenv("WINDMILL_WEBHOOK_URL", URL)
+    monkeypatch.delenv("WINDMILL_TOKEN", raising=False)
+
+
+@given("Windmill is configured")
+def _configured(context: dict[str, Any], monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("WINDMILL_WEBHOOK_URL", URL)
+    monkeypatch.setenv("WINDMILL_TOKEN", TOKEN)
+    context["erreur"] = None
+
+
+@given("Windmill returns HTTP 500")
+def _http_error(context: dict[str, Any]) -> None:
+    context["erreur"] = HTTPError(URL, 500, "Server Error", {}, None)  # type: ignore[arg-type]
+
+
+@given("Windmill is unreachable")
+def _unreachable(context: dict[str, Any]) -> None:
+    context["erreur"] = URLError("connexion refusee")
+
+
+def _envoyer(context: dict[str, Any], affected: int, scanned: int) -> None:
+    reponse = MagicMock()
+    reponse.status = 200
+    reponse.__enter__ = MagicMock(return_value=reponse)
+    reponse.__exit__ = MagicMock(return_value=False)
+
+    with patch("src.slack_report.urllib.request.urlopen") as ouvrir:
+        if context.get("erreur") is not None:
+            ouvrir.side_effect = context["erreur"]
+        else:
+            ouvrir.return_value = reponse
+        context["resultat"] = send_report(
+            [{"depot": f"org/depot-{i}", "elements": [f"modele-{i}"]} for i in range(affected)],
+            scanned,
+        )
+        context["appels"] = ouvrir
+
+
+@when("I send the report")
+def _send(context: dict[str, Any]) -> None:
+    _envoyer(context, affected=1, scanned=82)
+
+
+@when(parsers.parse("I send the report for {affected:d} affected repositories out of {scanned:d}"))
+def _send_counts(context: dict[str, Any], affected: int, scanned: int) -> None:
+    _envoyer(context, affected=affected, scanned=scanned)
+
+
+def _charge(context: dict[str, Any]) -> dict[str, Any]:
+    requete = context["appels"].call_args.args[0]
+    return json.loads(requete.data.decode())
+
+
+@then("no HTTP request should have been made")
+def _no_request(context: dict[str, Any]) -> None:
+    context["appels"].assert_not_called()
+
+
+@then("the request should have been made")
+def _request_made(context: dict[str, Any]) -> None:
+    context["appels"].assert_called_once()
+
+
+@then("the result should be False")
+def _false(context: dict[str, Any]) -> None:
+    assert context["resultat"] is False
+
+
+@then(parsers.parse('the payload should declare the report type "{attendu}"'))
+def _type(context: dict[str, Any], attendu: str) -> None:
+    assert _charge(context)["type_rapport"] == attendu
+
+
+@then(parsers.parse("the payload should list {attendu:d} repositories"))
+def _liste(context: dict[str, Any], attendu: int) -> None:
+    assert len(_charge(context)["depots"]) == attendu
+
+
+@then(parsers.parse("the payload should declare {attendu:d} scanned repositories"))
+def _scannes(context: dict[str, Any], attendu: int) -> None:
+    assert _charge(context)["total_analyses"] == attendu
+
+
+@then("the request should carry the Windmill token")
+def _jeton(context: dict[str, Any]) -> None:
+    requete = context["appels"].call_args.args[0]
+    assert requete.get_header("Authorization") == f"Bearer {TOKEN}"

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -6,6 +6,7 @@ from datetime import date
 from unittest.mock import MagicMock, patch
 from urllib.error import HTTPError, URLError
 
+import pytest
 from pytest_bdd import given, parsers, scenarios, then, when
 
 from src.deprecations import DeprecatedModel
@@ -161,7 +162,8 @@ def send_webhook_normal(webhook_setup: dict[str, object]) -> dict[str, object]:
             body="## Le modèle `gpt-4o` est retiring",
             assignees=["davebulaval"],
         )
-    return {"result": result, "urlopen_called": mock.called}
+    request = mock.call_args.args[0] if mock.called else None
+    return {"result": result, "urlopen_called": mock.called, "request": request}
 
 
 @when(
@@ -219,3 +221,32 @@ def check_webhook_result(webhook_result: dict[str, object], expected: str) -> No
 )
 def check_no_http_request(webhook_result: dict[str, object]) -> None:
     assert not webhook_result["urlopen_called"], "urlopen should not have been called in dry-run"
+
+
+@given("a webhook token is configured")
+def _token_configured(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LLM_SCAN_WEBHOOK_TOKEN", "jeton-crm")
+
+
+@given("no webhook token is configured")
+def _token_absent(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("LLM_SCAN_WEBHOOK_TOKEN", raising=False)
+
+
+@then("the request should carry the bearer token")
+def _carries_token(webhook_result: dict[str, object]) -> None:
+    """Without this header any protected destination answers 403.
+
+    That is exactly how the previous integration failed: the webhook fired on
+    every issue and was rejected, for months, with nobody able to diagnose it.
+    """
+    request = webhook_result["request"]
+    assert request is not None
+    assert request.get_header("Authorization") == "Bearer jeton-crm"
+
+
+@then("the request should carry no authorization header")
+def _carries_no_token(webhook_result: dict[str, object]) -> None:
+    request = webhook_result["request"]
+    assert request is not None
+    assert request.get_header("Authorization") is None


### PR DESCRIPTION
La verification d'issue existante etait sautee en dry-run : l'essai annoncait 72 issues alors que 36 existent deja et ne seraient pas recreees.

L'invariant du dry-run devient "aucune ecriture" plutot que "aucun appel gh" : la recherche d'issue est en lecture seule, la creation ne l'est pas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)