### PR TITLE
fix: reintegrer gemini-2.5-flash-lite au registre

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ flowchart TD
 | gemini-2.5-flash-exp-native-audio-thinking-dialog | google | shutdown | 2025-10-20 |
 | gemini-2.5-flash-image | google | retiring | 2026-10-02 |
 | gemini-2.5-flash-image-preview | google | shutdown | 2026-01-15 |
+| gemini-2.5-flash-lite | google | retiring | 2026-10-16 |
 | gemini-2.5-flash-lite-preview-06-17 | google | shutdown | 2025-11-18 |
 | gemini-2.5-flash-lite-preview-09-2025 | google | shutdown | 2026-03-31 |
 | gemini-2.5-flash-native-audio-preview-09-2025 | google | deprecated |  |

--- a/data/registry.json
+++ b/data/registry.json
@@ -302,6 +302,12 @@
       "shutdown_date": "2026-01-15"
     },
     {
+      "model": "gemini-2.5-flash-lite",
+      "provider": "google",
+      "status": "retiring",
+      "shutdown_date": "2026-10-16"
+    },
+    {
       "model": "gemini-2.5-flash-lite-preview-06-17",
       "provider": "google",
       "status": "shutdown",


### PR DESCRIPTION
## Contexte

En triant les PR de mise a jour du registre restees ouvertes (#49, #50, #53, #54, #57, #58, toutes fermees car remplacees par #247), une entree n'etait presente dans aucune autre : `gemini-2.5-flash-lite` (google, `retiring`, arret le 2026-10-16).

Elle figurait dans les flux [deprecations.info](https://deprecations.info/) du 15 mai au 1er aout 2026, puis a disparu de celui du 15 aout. Comme aucune de ces PR n'a ete mergee, l'entree n'a jamais atteint `data/registry.json` : le scanner ne signalerait pas un retrait pourtant prevu dans deux mois.

## Changement

- `data/registry.json` : ajout de l'entree, a sa place dans le tri `(provider, model)`
- `README.md` : section auto-generee regeneree via `update_readme`

Aucun pattern a ajouter : `gemini-2.5-flash-lite` est deja couvert par `\bgemini-2[\.-]5-flash(?:-[a-z0-9]+)*\b`.

`merge_registries` n'efface jamais d'entree : si le flux republie le modele, celui-ci sera simplement mis a jour.

## Verification

- `python -m src.validate_patterns` : tous les modeles du registre sont couverts
- `pytest tests/` : 502 tests verts (+1 cas de coherence pour la nouvelle entree)
- `update_readme(load_registry(), README.md)` ne produit plus de diff : registre et README sont coherents

🤖 Generated with [Claude Code](https://claude.com/claude-code)