### PR TITLE
ci: authentifier la mise a jour du registre par une GitHub App

### DIFF
--- a/.github/workflows/update-registry.yml
+++ b/.github/workflows/update-registry.yml
@@ -1,3 +1,25 @@
+# Mise a jour bimensuelle du registre depuis deprecations.info.
+#
+# Prerequis : une GitHub App installee sur ce depot, dont l'identifiant et la
+# cle privee sont les secrets REGISTRY_APP_ID et REGISTRY_APP_KEY. Permissions
+# requises : Contents en ecriture pour pousser la branche, Pull requests en
+# ecriture pour ouvrir la PR, Issues en ecriture pour signaler un flux
+# injoignable.
+#
+# Une App plutot que le jeton par defaut, alors que celui-ci aurait les droits :
+# GitHub refuse de declencher un workflow sur un evenement produit par
+# GITHUB_TOKEN. Une PR poussee avec ce jeton n'a donc AUCUNE CI, et affiche
+# "no checks reported" plutot que "checks failed". Le 2026-08-15, la PR #247
+# est arrivee avec vingt modeles qu'aucun pattern ne detectait et vingt-et-un
+# tests casses, sans le moindre signal. Le jeton d'installation d'une App
+# n'a pas cette restriction : la CI tourne, et une PR cassee se voit.
+#
+# L'App est distincte de celle du balayage d'organisation
+# (ORG_SWEEP_APP_ID / ORG_SWEEP_APP_KEY) : celle-ci est installee sur tous les
+# depots de l'organisation et n'a besoin que de Contents en LECTURE. Lui
+# accorder l'ecriture pour ce seul workflow etendrait ce droit a toute
+# l'organisation.
+
 name: Mise a jour du registre de deprecation
 
 on:
@@ -5,6 +27,9 @@ on:
     - cron: "0 6 1,15 * *"  # Le 1er et 15 de chaque mois a 06:00 UTC
   workflow_dispatch:
 
+# Les droits ci-dessous sont ceux de GITHUB_TOKEN, que seule l'action Claude
+# utilise encore en dernier recours. Le push et la PR passent par le jeton de
+# l'App.
 permissions:
   contents: write
   issues: write
@@ -14,7 +39,18 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
+      - name: Obtenir un jeton d'installation
+        id: jeton
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.REGISTRY_APP_ID }}
+          private-key: ${{ secrets.REGISTRY_APP_KEY }}
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Le jeton est conserve dans .git/config : c'est lui qui authentifie
+          # le `git push` plus bas, et donc lui qui declenche la CI sur la PR.
+          token: ${{ steps.jeton.outputs.token }}
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
@@ -24,7 +60,7 @@ jobs:
         run: python -m src.update_registry
         env:
           PYTHONPATH: ${{ github.workspace }}
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.jeton.outputs.token }}
           LLM_SCAN_ASSIGNEES: ${{ vars.LLM_SCAN_ASSIGNEES || '' }}
 
       - name: Detecter les changements du registre
@@ -48,7 +84,7 @@ jobs:
         id: push-branch
         if: steps.detect-changes.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.jeton.outputs.token }}
         run: |
           BRANCH="chore/update-registry-$(date +%Y-%m-%d)"
           git config user.name "github-actions[bot]"
@@ -71,6 +107,9 @@ jobs:
         uses: anthropics/claude-code-action@6c0083bb7289c31716797a039b6367b3079cc46e # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Le jeton de l'App, pour que le commit correctif de Claude declenche
+          # lui aussi la CI sur la PR.
+          github_token: ${{ steps.jeton.outputs.token }}
           prompt: |
             Le registre data/registry.json vient d'etre mis a jour avec de nouveaux
             modeles deprecies. Verifie que les patterns regex et les tests sont a jour.
@@ -80,6 +119,10 @@ jobs:
               (ex: "Chat model updates"), pas des model IDs. Elles sont ignorees par
               validate_patterns et le test de coherence. Ne cree PAS de patterns pour elles.
             - Les cles du registre sont en minuscules. Les patterns sont case-insensitive.
+            - tests/features/deprecations.feature s'execute contre le registre fige
+              tests/data/registry_fige.json, pas contre data/registry.json. Ne le
+              modifie PAS pour suivre un changement de statut amont : s'il echoue,
+              c'est un vrai bug de check_deprecation.
 
             1. Execute la validation des patterns :
                PYTHONPATH=. python -m src.validate_patterns --output-json
@@ -89,10 +132,8 @@ jobs:
             3. Execute les tests :
                PYTHONPATH=. python -m pytest tests/ -v --rootdir=.
             4. Si des tests echouent :
-               a. Corrige tests/features/deprecations.feature si des modeles ont change de
-                  statut (ex: un modele "actif" est maintenant deprecie dans le registre)
-               b. Corrige les autres tests BDD si necessaire
-               c. Re-execute les tests jusqu'a ce qu'ils passent
+               a. Corrige les tests BDD concernes, sauf deprecations.feature (voir ci-dessus)
+               b. Re-execute les tests jusqu'a ce qu'ils passent
             5. Execute le linter : ruff check src/ tests/ --fix && ruff format src/ tests/
             6. Si des changements ont ete faits, commit avec le message :
                "feat: update patterns and tests for new registry models"
@@ -109,7 +150,7 @@ jobs:
         id: create-pr
         if: steps.push-branch.outputs.branch != ''
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.jeton.outputs.token }}
         run: |
           gh pr create \
             --title "chore: mise a jour du registre de deprecation" \

--- a/tests/data/registry_fige.json
+++ b/tests/data/registry_fige.json
@@ -1,0 +1,53 @@
+{
+  "updated_at": "2026-01-01T00:00:00+00:00",
+  "models": [
+    {
+      "model": "claude-3-opus",
+      "provider": "anthropic",
+      "status": "shutdown",
+      "shutdown_date": "2026-01-05"
+    },
+    {
+      "model": "claude-3.5-haiku",
+      "provider": "anthropic",
+      "status": "deprecated",
+      "shutdown_date": null
+    },
+    {
+      "model": "claude-3.5-sonnet",
+      "provider": "anthropic",
+      "status": "shutdown",
+      "shutdown_date": "2025-10-28"
+    },
+    {
+      "model": "gpt-3.5-turbo",
+      "provider": "openai",
+      "status": "retiring",
+      "shutdown_date": "2026-10-23"
+    },
+    {
+      "model": "gpt-4o",
+      "provider": "openai",
+      "status": "retiring",
+      "shutdown_date": "2026-10-01"
+    },
+    {
+      "model": "gpt-4o-mini",
+      "provider": "openai",
+      "status": "retiring",
+      "shutdown_date": "2026-10-01"
+    },
+    {
+      "model": "o1-preview",
+      "provider": "openai",
+      "status": "shutdown",
+      "shutdown_date": "2025-07-28"
+    },
+    {
+      "model": "text-embedding-ada-002",
+      "provider": "openai",
+      "status": "retiring",
+      "shutdown_date": "2026-01-04"
+    }
+  ]
+}

--- a/tests/features/deprecations.feature
+++ b/tests/features/deprecations.feature
@@ -2,6 +2,10 @@ Feature: Model deprecation detection
   The scanner should identify deprecated or retiring models
   and provide deprecation information including shutdown dates.
 
+  Les statuts ci-dessous viennent de tests/data/registry_fige.json, pas du
+  registre de production : celui-ci est reecrit tous les quinze jours et ses
+  statuts ne sont pas des invariants testables.
+
   Scenario Outline: Detect deprecated models
     Given a model name "<model>"
     When I check its deprecation status

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -1,17 +1,38 @@
-"""BDD step definitions for model deprecation detection tests."""
+"""BDD step definitions for model deprecation detection tests.
+
+Ces scenarios s'executent contre `tests/data/registry_fige.json` et non contre
+`data/registry.json`. Le vrai registre est reecrit tous les quinze jours par le
+workflow de mise a jour : y coder en dur qu'un modele est `deprecated` faisait
+echouer la suite des que deprecations.info changeait son statut, ce qui n'apprend
+rien sur `check_deprecation`. Le registre fige teste la mecanique (les trois
+statuts, le retrait du suffixe de date, l'absence du registre) sur des donnees
+qui, elles, ne bougent pas.
+"""
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from pathlib import Path
 
+import pytest
 from pytest_bdd import given, parsers, scenarios, then, when
 
-from src.deprecations import DeprecatedModel, check_deprecation
+from src.deprecations import DeprecatedModel, check_deprecation, reload_deprecation_registry
 from src.issue_reporter import DeprecationAlert
 from src.scanner import scan_directory
 
 
 scenarios("features/deprecations.feature")
+
+_REGISTRE_FIGE = Path(__file__).parent / "data" / "registry_fige.json"
+
+
+@pytest.fixture(autouse=True)
+def registre_fige() -> Iterator[None]:
+    """Substitue le registre fige au registre de production le temps du test."""
+    reload_deprecation_registry(_REGISTRE_FIGE)
+    yield
+    reload_deprecation_registry()
 
 
 @given(


### PR DESCRIPTION
Corrige les deux causes systemiques relevees en revisant #247.

## 1. Les PR du registre n'avaient aucune CI

GitHub refuse de declencher un workflow sur un evenement produit par `GITHUB_TOKEN`. Le workflow poussait sa branche avec ce jeton : les PR affichaient donc **"no checks reported"**, pas "checks failed". La #247 est arrivee avec 20 modeles du registre qu'aucun pattern ne detectait et 21 tests casses, sans le moindre signal ; l'etape "Ajuster les patterns avec Claude" est en `continue-on-error` et avait echoue en silence.

Le workflow obtient maintenant un jeton d'installation de GitHub App (`actions/create-github-app-token`, meme action et meme version que `org-sweep.yml`) et s'en sert pour le checkout, le `git push`, le `gh pr create` et l'action Claude. Un jeton d'App n'a pas cette restriction : la CI tourne, une PR cassee se voit.

> [!IMPORTANT]
> **A configurer avant le prochain run planifie (1er septembre 06:00 UTC).** Il faut une GitHub App installee sur ce depot et deux secrets : `REGISTRY_APP_ID`, `REGISTRY_APP_KEY`. Permissions requises : **Contents: write** (pousser la branche), **Pull requests: write** (ouvrir la PR), **Issues: write** (signaler un flux injoignable). Sans ces secrets le workflow echoue immediatement, de facon visible, plutot que de produire des PR sans CI.
>
> C'est volontairement une App distincte de `ORG_SWEEP_APP_*` : celle-la est installee sur **tous** les depots de l'organisation avec Contents en lecture seule, et lui donner l'ecriture pour ce seul workflow etendrait ce droit partout.

## 2. `deprecations.feature` testait des donnees reecrites tous les 15 jours

Le fichier codait en dur `gpt-3.5-turbo -> deprecated`, `gpt-4o -> retiring`, etc. Ces statuts viennent de deprecations.info et changent sans preavis : la suite cassait a chaque changement amont sans rien apprendre sur `check_deprecation`. C'est ce qui a produit un des 21 echecs de la #247.

Les scenarios s'executent desormais contre `tests/data/registry_fige.json` (8 entrees, substitue par une fixture autouse via `reload_deprecation_registry`). Ils testent la mecanique : les trois statuts, le retrait du suffixe de date, l'absence du registre. Le registre de production n'est plus une entree de test.

Le prompt de l'etape Claude est corrige en consequence : il demandait explicitement de "corriger deprecations.feature si des modeles ont change de statut", ce qui revenait a faire reecrire l'oracle par le code teste.

## Verification

- `pytest tests/` : 502 verts
- Isolation prouvee : en passant `gpt-4o` a `shutdown` dans le registre fige, 3 scenarios echouent ; le registre de production, lui, est inchange
- `ruff` 0.15.10 (version epinglee en CI) et `mypy --strict` propres
- YAML du workflow valide

🤖 Generated with [Claude Code](https://claude.com/claude-code)