### PR TITLE
refactor: un seul chemin pour les requetes sortantes, et reparer le 403

### DIFF
--- a/src/deprecation_feed.py
+++ b/src/deprecation_feed.py
@@ -8,9 +8,10 @@ from __future__ import annotations
 import json
 import logging
 import time
-import urllib.request
 from datetime import date
 from typing import TYPE_CHECKING, Any
+
+from src.http import request_json
 
 
 if TYPE_CHECKING:
@@ -19,6 +20,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 FEED_URL = "https://deprecations.info/v1/deprecations.json"
+USER_AGENT = "llm-scanner/1.0"
 FEED_TIMEOUT = 10
 MAX_RETRIES = 3
 RETRY_DELAY = 2  # seconds
@@ -39,17 +41,23 @@ def fetch_deprecations() -> list[DeprecatedModel]:
     Returns an empty list on any network or parsing error (silent fallback).
     """
     for attempt in range(1, MAX_RETRIES + 1):
-        try:
-            req = urllib.request.Request(  # noqa: S310 - FEED_URL is a hardcoded https constant
-                FEED_URL, headers={"User-Agent": "llm-scanner/1.0"}
+        response = request_json(FEED_URL, timeout=FEED_TIMEOUT, user_agent=USER_AGENT)
+        if response.ok:
+            try:
+                data: list[dict[str, Any]] = json.loads(response.body)
+            except json.JSONDecodeError as exc:
+                logger.warning("Attempt %d/%d failed: %s", attempt, MAX_RETRIES, exc)
+            else:
+                return _parse_feed(data)
+        else:
+            logger.warning(
+                "Attempt %d/%d failed: %s",
+                attempt,
+                MAX_RETRIES,
+                response.erreur or response.status,
             )
-            with urllib.request.urlopen(req, timeout=FEED_TIMEOUT) as resp:  # noqa: S310
-                data: list[dict[str, Any]] = json.loads(resp.read().decode())
-            return _parse_feed(data)
-        except (OSError, json.JSONDecodeError, ValueError) as exc:
-            logger.warning("Attempt %d/%d failed: %s", attempt, MAX_RETRIES, exc)
-            if attempt < MAX_RETRIES:
-                time.sleep(RETRY_DELAY)
+        if attempt < MAX_RETRIES:
+            time.sleep(RETRY_DELAY)
     return []
 
 

--- a/src/http.py
+++ b/src/http.py
@@ -1,0 +1,89 @@
+"""Requetes HTTP sortantes, avec la meme politique d'echec partout.
+
+Trois modules appelaient urllib directement : le flux de deprecations, le
+webhook CRM et le rapport Slack. Chacun avait sa liste d'exceptions a
+rattraper, et elles n'etaient pas equivalentes.
+
+L'ecart le plus couteux portait sur les codes d'erreur HTTP. `urlopen` ne
+renvoie pas une reponse pour un 4xx ou un 5xx : il leve `HTTPError`. Le
+webhook rattrapait cette exception avec les pannes reseau, puis testait plus
+bas `if status == 403` sur une variable qui, a cet endroit, ne pouvait valoir
+qu'un code 2xx. Le message d'aide sur le jeton manquant -- la raison meme pour
+laquelle le module distingue l'URL du secret -- ne s'est donc jamais affiche.
+
+`Reponse` rend la distinction explicite : un code HTTP est une reponse du
+serveur, `status=None` est une absence de reponse.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+@dataclass(frozen=True)
+class Reponse:
+    """Issue d'une requete sortante.
+
+    Attributes:
+        status: Le code HTTP renvoye, ou None si rien n'est revenu du tout
+            (panne reseau, delai depasse, URL invalide).
+        body: Le corps de la reponse, y compris celui d'une erreur HTTP.
+        erreur: Description lisible de l'echec, vide en cas de succes.
+    """
+
+    status: int | None
+    body: str
+    erreur: str = ""
+
+    @property
+    def ok(self) -> bool:
+        """Vrai pour un code 2xx."""
+        return self.status is not None and 200 <= self.status < 300
+
+
+def request_json(
+    url: str,
+    *,
+    timeout: int,
+    payload: object | None = None,
+    token: str = "",
+    user_agent: str = "",
+) -> Reponse:
+    """Emet une requete et renvoie son issue. Ne leve jamais.
+
+    Un `payload` non nul est serialise en JSON et bascule la requete en POST.
+
+    Args:
+        url: L'URL a joindre.
+        timeout: Delai maximal, en secondes.
+        payload: Corps a serialiser en JSON, ou None pour un GET.
+        token: Jeton porteur, ajoute en `Authorization` s'il est fourni.
+        user_agent: En-tete `User-Agent`, ajoute s'il est fourni.
+    """
+    data = json.dumps(payload, ensure_ascii=False).encode("utf-8") if payload is not None else None
+
+    headers = {}
+    if data is not None:
+        headers["Content-Type"] = "application/json"
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    if user_agent:
+        headers["User-Agent"] = user_agent
+
+    request = Request(url, data=data, headers=headers)  # noqa: S310 - URL de configuration, jamais saisie
+
+    try:
+        with urlopen(request, timeout=timeout) as response:  # noqa: S310
+            return Reponse(status=response.status, body=response.read().decode(errors="replace"))
+    except HTTPError as exc:
+        # A rattraper avant URLError, dont HTTPError herite.
+        return Reponse(
+            status=exc.code,
+            body=exc.read().decode(errors="replace"),
+            erreur=f"HTTP {exc.code}",
+        )
+    except (URLError, OSError, TimeoutError, ValueError) as exc:
+        return Reponse(status=None, body="", erreur=str(exc))

--- a/src/slack_report.py
+++ b/src/slack_report.py
@@ -12,12 +12,11 @@ still runs and still opens GitHub issues; only the Slack message is skipped.
 
 from __future__ import annotations
 
-import json
 import logging
 import os
-import urllib.error
-import urllib.request
 from dataclasses import dataclass
+
+from src.http import request_json
 
 
 logger = logging.getLogger(__name__)
@@ -72,23 +71,18 @@ def send_report(
         "total_analyses": total_scanned,
         "channel_id": channel_id,
     }
-    request = urllib.request.Request(  # noqa: S310 - the URL comes from our own configuration
+    response = request_json(
         config.webhook_url,
-        data=json.dumps(payload).encode(),
-        method="POST",
-        headers={
-            "Authorization": f"Bearer {config.token}",
-            "Content-Type": "application/json",
-        },
+        payload=payload,
+        token=config.token,
+        timeout=TIMEOUT_SECONDS,
     )
 
-    try:
-        with urllib.request.urlopen(request, timeout=TIMEOUT_SECONDS) as response:  # noqa: S310
-            logger.info("Slack report sent (HTTP %s)", response.status)
-            return True
-    except urllib.error.HTTPError as exc:
-        detail = exc.read().decode(errors="replace")[:300]
-        logger.warning("Windmill returned HTTP %s: %s", exc.code, detail)
-    except (urllib.error.URLError, TimeoutError) as exc:
-        logger.warning("Could not reach Windmill: %s", exc)
+    if response.ok:
+        logger.info("Slack report sent (HTTP %s)", response.status)
+        return True
+    if response.status is None:
+        logger.warning("Could not reach Windmill: %s", response.erreur)
+    else:
+        logger.warning("Windmill returned HTTP %s: %s", response.status, response.body[:300])
     return False

--- a/src/webhook.py
+++ b/src/webhook.py
@@ -17,8 +17,8 @@ import logging
 import os
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
-from urllib.error import URLError
-from urllib.request import Request, urlopen
+
+from src.http import request_json
 
 
 if TYPE_CHECKING:
@@ -101,31 +101,21 @@ def _post(url: str, payload: dict[str, object]) -> bool:
 
     Returns True on success (2xx), False on any error.
     """
-    data = json.dumps(payload, ensure_ascii=False).encode("utf-8")
-    headers = {"Content-Type": "application/json"}
     token = os.environ.get("LLM_SCAN_WEBHOOK_TOKEN", "").strip()
-    if token:
-        headers["Authorization"] = f"Bearer {token}"
+    response = request_json(url, payload=payload, token=token, timeout=_WEBHOOK_TIMEOUT_SECONDS)
 
-    request = Request(url, data=data, headers=headers)  # noqa: S310
-
-    try:
-        with urlopen(request, timeout=_WEBHOOK_TIMEOUT_SECONDS) as response:  # noqa: S310
-            status = response.status
-    except (URLError, OSError, TimeoutError) as exc:
-        logger.warning("Webhook POST to %s failed: %s", url, exc)
-        return False
-
-    if 200 <= status < 300:
-        logger.info("Webhook POST to %s succeeded (HTTP %d)", url, status)
+    if response.ok:
+        logger.info("Webhook POST to %s succeeded (HTTP %s)", url, response.status)
         return True
 
-    if status == _HTTP_FORBIDDEN and not token:
+    if response.status is None:
+        logger.warning("Webhook POST to %s failed: %s", url, response.erreur)
+    elif response.status == _HTTP_FORBIDDEN and not token:
         logger.warning(
             "Webhook POST to %s returned HTTP 403 and no token was provided. "
             "Set LLM_SCAN_WEBHOOK_TOKEN if the destination requires authentication.",
             url,
         )
     else:
-        logger.warning("Webhook POST to %s returned HTTP %d", url, status)
+        logger.warning("Webhook POST to %s returned HTTP %d", url, response.status)
     return False

--- a/tests/features/webhook.feature
+++ b/tests/features/webhook.feature
@@ -54,3 +54,13 @@ Feature: Webhook notifications for CRM integration
     And a webhook URL that returns HTTP 200
     When I send the webhook
     Then the request should carry no authorization header
+
+  Scenario: A 403 without a token names the variable to set
+    # urlopen leve HTTPError pour tout code >= 400 : le code de statut etait
+    # rattrape avec les pannes reseau, et ce message -- la raison meme pour
+    # laquelle le module distingue l'URL du secret -- ne sortait jamais.
+    Given no webhook token is configured
+    And a webhook URL that returns HTTP 403
+    When I send the webhook
+    Then the webhook result should be False
+    And the warning should mention "LLM_SCAN_WEBHOOK_TOKEN"

--- a/tests/test_deprecation_feed.py
+++ b/tests/test_deprecation_feed.py
@@ -13,6 +13,16 @@ from src.deprecation_feed import fetch_deprecations
 scenarios("features/deprecation_feed.feature")
 
 
+def _reponse_ok(feed: list[dict[str, str]]) -> MagicMock:
+    """Reponse HTTP 200 dont le corps est le flux serialise."""
+    reponse = MagicMock()
+    reponse.status = 200
+    reponse.read = MagicMock(return_value=json.dumps(feed).encode())
+    reponse.__enter__ = MagicMock(return_value=reponse)
+    reponse.__exit__ = MagicMock(return_value=False)
+    return reponse
+
+
 _SAMPLE_FEED = [
     {
         "provider": "OpenAI",
@@ -30,11 +40,7 @@ def given_transient_failures() -> MagicMock:
     responses: list[object] = [
         OSError("Connection refused"),
         OSError("Connection reset"),
-        MagicMock(
-            read=MagicMock(return_value=json.dumps(_SAMPLE_FEED).encode()),
-            __enter__=lambda s: s,
-            __exit__=MagicMock(return_value=False),
-        ),
+        _reponse_ok(_SAMPLE_FEED),
     ]
     mock = MagicMock(side_effect=responses)
     return mock
@@ -60,13 +66,7 @@ def given_category_header(header: str) -> MagicMock:
     ensuite une par une, avec un avertissement a chaque appel.
     """
     feed = [{"provider": "OpenAI", "model_id": header, "shutdown_date": "2026-06-03"}]
-    return MagicMock(
-        return_value=MagicMock(
-            read=MagicMock(return_value=json.dumps(feed).encode()),
-            __enter__=lambda s: s,
-            __exit__=MagicMock(return_value=False),
-        )
-    )
+    return MagicMock(return_value=_reponse_ok(feed))
 
 
 @when(
@@ -75,7 +75,7 @@ def given_category_header(header: str) -> MagicMock:
 )
 def fetch(mock_urlopen: MagicMock) -> list[object]:
     with (
-        patch("src.deprecation_feed.urllib.request.urlopen", mock_urlopen),
+        patch("src.http.urlopen", mock_urlopen),
         patch("src.deprecation_feed.time.sleep"),
     ):
         return fetch_deprecations()

--- a/tests/test_slack_report.py
+++ b/tests/test_slack_report.py
@@ -61,10 +61,11 @@ def _unreachable(context: dict[str, Any]) -> None:
 def _envoyer(context: dict[str, Any], affected: int, scanned: int) -> None:
     reponse = MagicMock()
     reponse.status = 200
+    reponse.read = MagicMock(return_value=b"")
     reponse.__enter__ = MagicMock(return_value=reponse)
     reponse.__exit__ = MagicMock(return_value=False)
 
-    with patch("src.slack_report.urllib.request.urlopen") as ouvrir:
+    with patch("src.http.urlopen") as ouvrir:
         if context.get("erreur") is not None:
             ouvrir.side_effect = context["erreur"]
         else:

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import date
 from unittest.mock import MagicMock, patch
 from urllib.error import HTTPError, URLError
@@ -104,6 +105,24 @@ def given_url_500() -> dict[str, object]:
 
 
 @given(
+    "a webhook URL that returns HTTP 403",
+    target_fixture="webhook_setup",
+)
+def given_url_403() -> dict[str, object]:
+    return {
+        "url": "https://example.com/webhook",
+        "error": HTTPError(
+            "https://example.com/webhook",
+            403,
+            "Forbidden",
+            {},
+            None,  # type: ignore[arg-type]
+        ),
+        "status": None,
+    }
+
+
+@given(
     "a webhook URL that causes a network error",
     target_fixture="webhook_setup",
 )
@@ -138,6 +157,7 @@ def _mock_urlopen(setup: dict[str, object]) -> MagicMock:
     else:
         response = MagicMock()
         response.status = setup["status"]
+        response.read = MagicMock(return_value=b"")
         response.__enter__ = MagicMock(return_value=response)
         response.__exit__ = MagicMock(return_value=False)
         mock.return_value = response
@@ -148,10 +168,13 @@ def _mock_urlopen(setup: dict[str, object]) -> MagicMock:
     "I send the webhook",
     target_fixture="webhook_result",
 )
-def send_webhook_normal(webhook_setup: dict[str, object]) -> dict[str, object]:
+def send_webhook_normal(
+    webhook_setup: dict[str, object],
+    caplog: pytest.LogCaptureFixture,
+) -> dict[str, object]:
     mock = _mock_urlopen(webhook_setup)
     alerts = _make_alerts()
-    with patch("src.webhook.urlopen", mock):
+    with caplog.at_level(logging.WARNING), patch("src.http.urlopen", mock):
         result = send_webhook(
             url=str(webhook_setup["url"]),
             repo_name="org/repo",
@@ -163,7 +186,12 @@ def send_webhook_normal(webhook_setup: dict[str, object]) -> dict[str, object]:
             assignees=["davebulaval"],
         )
     request = mock.call_args.args[0] if mock.called else None
-    return {"result": result, "urlopen_called": mock.called, "request": request}
+    return {
+        "result": result,
+        "urlopen_called": mock.called,
+        "request": request,
+        "warnings": caplog.text,
+    }
 
 
 @when(
@@ -173,7 +201,7 @@ def send_webhook_normal(webhook_setup: dict[str, object]) -> dict[str, object]:
 def send_webhook_dry_run(webhook_setup: dict[str, object]) -> dict[str, object]:
     mock = _mock_urlopen(webhook_setup)
     alerts = _make_alerts()
-    with patch("src.webhook.urlopen", mock):
+    with patch("src.http.urlopen", mock):
         result = send_webhook(
             url=str(webhook_setup["url"]),
             repo_name="org/repo",
@@ -250,3 +278,10 @@ def _carries_no_token(webhook_result: dict[str, object]) -> None:
     request = webhook_result["request"]
     assert request is not None
     assert request.get_header("Authorization") is None
+
+
+@then(parsers.cfparse('the warning should mention "{text}"'))
+def check_warning_mentions(webhook_result: dict[str, object], text: str) -> None:
+    assert text in str(webhook_result["warnings"]), (
+        f"Expected '{text}' in warnings: {webhook_result['warnings']}"
+    )


### PR DESCRIPTION
Dernier des trois chantiers de simplification. Contrairement aux deux precedents, celui-ci **corrige un bug** que la consolidation a mis au jour.

## Le bug : le message d'aide sur le 403 ne s'affichait jamais

`urlopen` ne renvoie pas une reponse pour un 4xx ou un 5xx : **il leve `HTTPError`**. `webhook._post` rattrapait cette exception au meme titre que les pannes reseau :

```python
try:
    with urlopen(request, timeout=...) as response:
        status = response.status
except (URLError, OSError, TimeoutError) as exc:      # <- HTTPError passe ici
    logger.warning("Webhook POST to %s failed: %s", url, exc)
    return False

if 200 <= status < 300:
    return True
if status == _HTTP_FORBIDDEN and not token:            # <- inatteignable
    logger.warning("... Set LLM_SCAN_WEBHOOK_TOKEN ...")
```

Passe le `return True`, `status` ne peut valoir qu'un code 2xx. La branche 403 etait du code mort. Or le docstring du module dit explicitement pourquoi elle existe :

> Storing the URL as a secret is what made the previous integration fail silently for months, with a 403 nobody could diagnose because nobody could read the destination.

Le diagnostic ecrit pour eviter que ca se reproduise ne se declenchait pas.

## Le correctif

`src/http.py` distingue les deux cas : un code HTTP est une reponse du serveur (`status=403`), une panne reseau est une absence de reponse (`status=None`). `HTTPError` est rattrapee avant `URLError`, dont elle herite.

Les trois appelants -- flux de deprecations, webhook CRM, rapport Slack -- gardent leurs messages, leurs niveaux de log et leurs valeurs de retour a l'identique.

## Verification

- 505 tests verts (+1)
- Le nouveau scenario `A 403 without a token names the variable to set` echoue si on retire la branche `HTTPError` de `src/http.py` : verifie, il retombe sur `Webhook POST failed: HTTP Error 403` sans nommer la variable
- Les tests simulent `src.http.urlopen` : un seul seuil au lieu de trois
- Les fausses reponses gagnent `.read()` et `.status`, que le code lit maintenant au lieu de les deviner
- `ruff` 0.15.10 et `mypy --strict` propres

🤖 Generated with [Claude Code](https://claude.com/claude-code)