### PR TITLE
ci: linter les tests, mesurer la couverture, decoupler main.feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,14 @@ jobs:
       - name: Install ruff
         run: pip install ruff==0.15.10
 
+      # tests/ est linte au meme titre que src/. Le pre-commit couvrait deja les
+      # deux, mais il n'est pas execute en CI : une violation dans un test
+      # passait donc chez quiconque n'avait pas installe le hook.
       - name: Ruff check
-        run: ruff check src/
+        run: ruff check src/ tests/
 
       - name: Ruff format check
-        run: ruff format --check src/
+        run: ruff format --check src/ tests/
 
   test:
     runs-on: ubuntu-latest
@@ -40,10 +43,17 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: pip install pytest pytest-bdd
+        run: pip install pytest pytest-bdd pytest-cov
 
+      # Le seuil est un cliquet contre la regression, pas une cible : il est
+      # sous la couverture actuelle pour qu'un test legitimement difficile a
+      # ecrire ne bloque pas un correctif, mais assez haut pour qu'on ne puisse
+      # pas ajouter une branche de detection sans le test qui va avec. Un
+      # modele non detecte ne produit aucune erreur, juste un silence.
       - name: Run tests
-        run: python -m pytest tests/ -v --rootdir=.
+        run: >-
+          python -m pytest tests/ -v --rootdir=.
+          --cov=src --cov-report=term-missing --cov-fail-under=85
 
   typecheck:
     runs-on: ubuntu-latest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,10 +2,35 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
 from pytest_bdd import given
+
+from src.deprecations import reload_deprecation_registry
+
+
+REGISTRE_FIGE = Path(__file__).parent / "data" / "registry_fige.json"
+
+
+@pytest.fixture
+def registre_fige() -> Iterator[None]:
+    """Substitue le registre fige au registre de production le temps du test.
+
+    A activer par `pytestmark = pytest.mark.usefixtures("registre_fige")` dans
+    tout module dont les assertions portent sur le STATUT d'un modele ou sur le
+    fait qu'il soit deprecie. data/registry.json est reecrit tous les quinze
+    jours depuis deprecations.info : un scenario qui affirme que `gpt-4.1` est
+    encore actif est vrai aujourd'hui et faux le jour ou OpenAI l'annonce, sans
+    qu'une seule ligne de code ait bouge.
+
+    test_coherence est la seule exception assumee : sa raison d'etre est
+    justement de verifier le registre de production contre les patterns.
+    """
+    reload_deprecation_registry(REGISTRE_FIGE)
+    yield
+    reload_deprecation_registry()
 
 
 @pytest.fixture

--- a/tests/data/registry_fige.json
+++ b/tests/data/registry_fige.json
@@ -26,6 +26,18 @@
       "shutdown_date": "2099-10-23"
     },
     {
+      "model": "gpt-4",
+      "provider": "openai",
+      "status": "retiring",
+      "shutdown_date": "2099-10-23"
+    },
+    {
+      "model": "gpt-4-turbo",
+      "provider": "openai",
+      "status": "retiring",
+      "shutdown_date": "2099-10-23"
+    },
+    {
       "model": "gpt-4o",
       "provider": "openai",
       "status": "retiring",

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -11,28 +11,19 @@ qui, elles, ne bougent pas.
 
 from __future__ import annotations
 
-from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
 from pytest_bdd import given, parsers, scenarios, then, when
 
-from src.deprecations import DeprecatedModel, check_deprecation, reload_deprecation_registry
+from src.deprecations import DeprecatedModel, check_deprecation
 from src.issue_reporter import DeprecationAlert
 from src.scanner import scan_directory
 
 
 scenarios("features/deprecations.feature")
 
-_REGISTRE_FIGE = Path(__file__).parent / "data" / "registry_fige.json"
-
-
-@pytest.fixture(autouse=True)
-def registre_fige() -> Iterator[None]:
-    """Substitue le registre fige au registre de production le temps du test."""
-    reload_deprecation_registry(_REGISTRE_FIGE)
-    yield
-    reload_deprecation_registry()
+pytestmark = pytest.mark.usefixtures("registre_fige")
 
 
 @given(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,11 @@
-"""BDD step definitions for main CLI module tests."""
+"""BDD step definitions for main CLI module tests.
+
+Les scenarios de bout en bout s'executent contre `tests/data/registry_fige.json`
+et non contre `data/registry.json`. Ils affirment qu'un modele est deprecie et
+qu'un autre ne l'est pas ; or le vrai registre est reecrit tous les quinze jours
+depuis deprecations.info. « `gpt-4.1` n'est pas signale » est vrai aujourd'hui et
+faux le jour ou OpenAI annonce son retrait, sans qu'une ligne de code ait bouge.
+"""
 
 from __future__ import annotations
 
@@ -6,6 +13,7 @@ from datetime import date
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 from pytest_bdd import given, parsers, scenarios, then, when
 
 from src.deprecations import DeprecatedModel
@@ -16,6 +24,8 @@ from src.scanner import scan_directory
 
 
 scenarios("features/main.feature")
+
+pytestmark = pytest.mark.usefixtures("registre_fige")
 
 
 def _make_match(model: str, match_type: str = "llm") -> ScanMatch:


### PR DESCRIPTION
Trois trous de filet sans rapport entre eux, sauf qu'aucun ne se manifeste par une erreur.

## 1. La CI ne lintait que `src/`

`ruff check src/` et `ruff format --check src/`. Une violation dans `tests/` passait la CI sans bruit. Le pre-commit couvre bien les deux, mais **il n'est pas execute en CI** : le garde-fou reposait entierement sur le fait que chaque contributeur ait installe le hook.

Ce n'est pas theorique. Les modifications de tests des PR #250, #251 et #252 contenaient des `D205`, `D209` et `I001` — seul le hook local les a vus. Un contributeur sans hook aurait merge du code non conforme, et le premier a relancer `ruff` ensuite aurait herite d'un diff qui n'est pas le sien.

## 2. Aucune couverture mesuree

Ajout de `pytest-cov` et d'un seuil `--cov-fail-under=85`.

Le seuil est **un cliquet contre la regression, pas une cible**. Il est sous les 87,88 % actuels pour qu'un test legitimement difficile a ecrire ne bloque pas un correctif urgent, mais assez haut pour qu'on ne puisse pas ajouter une branche de detection sans le test qui va avec. C'est la nature de l'outil qui le justifie : un modele deprecie non detecte ne leve rien, ne casse rien, ne s'affiche nulle part. Il produit un silence, indiscernable d'un depot sain.

Etat actuel par module :

| Module | Couverture |
|---|---|
| `patterns`, `http`, `gh`, `webhook`, `slack_report`, `models` | 100 % |
| `issue_reporter` | 97 % |
| `scanner` | 92 % |
| `deprecations`, `main` | 90 % |
| `deprecation_feed` | 84 % |
| `org_sweep` | 79 % |
| `update_registry` | 70 % |
| `validate_patterns` | 54 % |
| **Total** | **88 %** |

Les deux plus bas sont des scripts CLI dont le `main()` et le formatage de sortie ne sont pas testes ; c'est la marge que laisse le seuil.

## 3. `main.feature` interrogeait le registre de production

Le dernier couplage. Trois scenarios de bout en bout affirment que `gpt-4.1`, `gpt-5.1` et `text-embedding-3-small` **ne sont pas** signales, en lisant `data/registry.json`. C'est vrai aujourd'hui et faux le jour ou OpenAI annonce leur retrait, sans qu'une ligne de code ait bouge — exactement le defaut corrige dans #249 pour `deprecations.feature`, qu'il restait a finir.

Ces scenarios passent au registre fige (`gpt-4` et `gpt-4-turbo` y sont ajoutes). La fixture demenage dans `conftest.py` et devient un opt-in explicite par module (`pytestmark = pytest.mark.usefixtures("registre_fige")`) plutot qu'un `autouse` local.

`test_coherence` garde volontairement le registre reel : verifier que chaque modele de production est couvert par un pattern est sa raison d'etre.

## Verification

- 505 tests verts, couverture 87,88 % > 85 %
- Isolation prouvee : en ajoutant `gpt-4.1` au registre fige, `test_endtoend_mixed_project_separates_deprecated_from_active` tombe — les scenarios lisent bien le registre fige et non celui de production
- `ruff` 0.15.10 et `mypy --strict` propres sur `src/` **et** `tests/`
- YAML du workflow valide

🤖 Generated with [Claude Code](https://claude.com/claude-code)