### PR TITLE
feat: laisser le depot analyse declarer ce qui n'est pas de la configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,60 @@ configuré, le journal le dit explicitement au lieu de laisser un code d'erreur 
 
 Les issues sont désactivées par défaut sur les forks GitHub. L'action échouera si elle détecte des modèles dépréciés mais ne peut pas créer d'issues. Activez les issues dans **Settings > General > Features > Issues** du repo.
 
+### Exclure des fichiers qui ne sont pas de la configuration
+
+Le scanner compare des chaînes de caractères ; il ne sait pas distinguer
+`model = "o4-mini"` d'une phrase de prose qui cite `o4-mini`. Un dépôt qui
+contient de la donnée, des fixtures ou de la veille technologique déclenchera
+donc des faux positifs qui reviennent à chaque passage.
+
+Le dépôt scanné déclare lui-même ce qui n'est pas de la configuration, dans un
+fichier **`.llm-scan-ignore`** à sa racine :
+
+```gitignore
+# Résumés d'articles de veille : citent des noms de modèles en prose,
+# aucune configuration.
+src/baseline_automation/windmill/f/bgy/ingestion/_articles_seed.py
+
+# Jeux de données de test
+tests/fixtures/
+```
+
+Règles de correspondance :
+
+| Motif | Ce qu'il couvre |
+|---|---|
+| `seed.py` | ce nom de fichier **à n'importe quelle profondeur** |
+| `fixtures/` | ce dossier et tout son contenu, qui n'est même pas parcouru |
+| `src/data/seed.py` | ce chemin précis, relatif à la racine du dépôt |
+| `*_seed.py` | tout fichier dont le nom finit ainsi |
+| `docs/*.md` | les fichiers `.md` sous `docs/` |
+
+Les lignes vides et celles commençant par `#` sont ignorées. Les chemins sont
+comparés en séparateurs POSIX, donc un motif écrit une fois vaut sur les trois
+systèmes.
+
+Chaque chemin écarté est **nommé dans le journal du scan**, pas seulement
+compté. Un motif trop large est ainsi visible dans les logs de l'exécution, au
+lieu de produire un « 0 modèle déprécié » qui aurait l'air d'un scan complet.
+
+Le fichier est lu depuis le dépôt analysé, y compris lors du balayage mensuel
+de l'organisation : aucune configuration centrale à tenir à jour.
+
+En dernier recours, l'action accepte aussi un `exclude-paths`, qui s'ajoute au
+fichier du dépôt :
+
+```yaml
+      - uses: Baseline-quebec/tracking-llm-discontinued@main
+        with:
+          repo-name: ${{ github.repository }}
+          exclude-paths: "docs/veille/, *_seed.py"
+```
+
+Préférez le fichier. Une exclusion versionnée dans le dépôt qu'elle concerne se
+relit avec lui ; une exclusion posée dans le workflow est invisible depuis le
+code qu'elle fait taire.
+
 ---
 
 ## Développement et maintenance du repo
@@ -444,6 +498,7 @@ data/
 src/
   patterns.py            # Patterns regex pour la detection de modeles
   scanner.py             # Parcours de repertoire et scan de fichiers
+  scan_ignore.py         # Exclusions declarees par le depot (.llm-scan-ignore)
   models.py              # Modeles de donnees (ScanMatch, ScanResult)
   deprecations.py        # Chargement du registre + gestion des suffixes de date
   deprecation_feed.py    # Flux live depuis deprecations.info

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,15 @@ inputs:
     description: "If true, scan only without creating issues"
     required: false
     default: "false"
+  exclude-paths:
+    description: >
+      Motifs de chemins a exclure du scan, separes par des virgules ou des
+      sauts de ligne. S'ajoutent au fichier .llm-scan-ignore du depot analyse,
+      qui reste le moyen recommande : une exclusion versionnee dans le depot
+      qu'elle concerne se relit avec lui, alors qu'une exclusion posee ici est
+      invisible depuis le code qu'elle fait taire.
+    required: false
+    default: ""
   webhook-url:
     description: >
       Optional webhook URL to POST issue details for CRM integration. Pass it
@@ -56,6 +65,7 @@ runs:
         SCAN_PATH: ${{ github.workspace }}
         SCAN_ASSIGNEES: ${{ inputs.assignees }}
         SCAN_DRY_RUN: ${{ inputs.dry-run }}
+        SCAN_EXCLUDE_PATHS: ${{ inputs.exclude-paths }}
         SCAN_WEBHOOK_URL: ${{ inputs.webhook-url }}
         LLM_SCAN_WEBHOOK_TOKEN: ${{ inputs.webhook-token }}
         PYTHONPATH: ${{ github.action_path }}
@@ -69,6 +79,10 @@ runs:
 
         if [ "$SCAN_DRY_RUN" = "true" ]; then
           ARGS+=(--dry-run)
+        fi
+
+        if [ -n "$SCAN_EXCLUDE_PATHS" ]; then
+          ARGS+=(--exclude-paths "$SCAN_EXCLUDE_PATHS")
         fi
 
         if [ -n "$SCAN_WEBHOOK_URL" ]; then

--- a/src/main.py
+++ b/src/main.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from src.issue_reporter import alerts_from_matches, create_issues, unique_lifecycles
+from src.scan_ignore import IGNORE_FILENAME, parse_inline_patterns
 from src.scanner import scan_directory
 
 
@@ -52,6 +53,14 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default="",
         help="Optional webhook URL to POST issue details for CRM integration",
     )
+    parser.add_argument(
+        "--exclude-paths",
+        default="",
+        help=(
+            "Motifs de chemins a exclure du scan, separes par des virgules ou "
+            f"des sauts de ligne. S'ajoutent au {IGNORE_FILENAME} du depot."
+        ),
+    )
     return parser.parse_args(argv)
 
 
@@ -67,7 +76,11 @@ def main(argv: list[str] | None = None) -> None:
         sys.exit(1)
 
     # Step 1: Scan for model references
-    result = scan_directory(scan_path, args.repo_name)
+    result = scan_directory(
+        scan_path,
+        args.repo_name,
+        extra_ignore_patterns=parse_inline_patterns(args.exclude_paths),
+    )
     logger.info("Found %d model references in %s", result.match_count, args.repo_name)
 
     # Step 2: Check for deprecated models

--- a/src/scan_ignore.py
+++ b/src/scan_ignore.py
@@ -1,0 +1,168 @@
+"""Exclusions de scan declarees par le depot analyse.
+
+Le scanner raisonne sur des chaines de caracteres, pas sur du sens : il ne fait
+pas la difference entre `model = "o4-mini"` et une phrase de prose qui cite
+`o4-mini`. Certains fichiers sont de la donnee, pas de la configuration, et
+aucune heuristique generique ne les distinguera de facon fiable.
+
+Cas reel : `_articles_seed.py` dans baseline-automation contient les resumes
+d'articles d'une revue de veille en IA. L'un d'eux rapporte l'annonce du retrait
+de GPT-4o par OpenAI et cite `o4-mini` dans sa phrase. Le scanner a ouvert une
+issue de depreciation sur un depot dont tout le code tourne deja sur Anthropic,
+et l'aurait rouverte a chaque passage.
+
+Le depot analyse declare donc lui-meme ce qui n'est pas de la configuration,
+dans un fichier `.llm-scan-ignore` a sa racine. C'est une decision explicite,
+versionnee et relisible, plutot qu'une heuristique qui deciderait a sa place.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from fnmatch import fnmatch
+from pathlib import Path, PurePosixPath
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+logger = logging.getLogger(__name__)
+
+IGNORE_FILENAME = ".llm-scan-ignore"
+
+COMMENT_PREFIX = "#"
+
+
+@dataclass(frozen=True)
+class ScanIgnore:
+    """Ensemble de motifs d'exclusion applique aux chemins scannes."""
+
+    patterns: tuple[str, ...] = ()
+
+    def __bool__(self) -> bool:
+        """Vrai si au moins un motif est defini."""
+        return bool(self.patterns)
+
+    def matches(self, relative_path: str) -> bool:
+        """Vrai si le chemin, ou l'un de ses dossiers parents, est exclu.
+
+        Le chemin est relatif a la racine scannee et compare en separateurs
+        POSIX, pour que les motifs ecrits une fois valent sur les trois systemes.
+
+        Args:
+            relative_path: Chemin relatif a la racine du scan.
+
+        Returns:
+            True si un motif couvre ce chemin.
+        """
+        if not self.patterns:
+            return False
+
+        chemin = PurePosixPath(relative_path.replace("\\", "/"))
+        # Exclure un dossier doit exclure tout ce qu'il contient : on teste le
+        # chemin lui-meme puis chacun de ses ancetres, sans quoi `docs/` ne
+        # couvrirait pas `docs/veille/articles.py`.
+        candidats = [chemin.as_posix()]
+        candidats.extend(
+            parent.as_posix() for parent in chemin.parents if parent.as_posix() != "."
+        )
+
+        return any(
+            _motif_couvre(motif, candidat) for motif in self.patterns for candidat in candidats
+        )
+
+
+def _motif_couvre(motif: str, candidat: str) -> bool:
+    """Vrai si un motif couvre un chemin candidat."""
+    # Le `/` final est la facon usuelle de dire « ce dossier » ; le retirer
+    # laisse la comparaison porter sur le chemin du dossier lui-meme.
+    motif = motif.rstrip("/")
+    if not motif:
+        return False
+
+    if fnmatch(candidat, motif):
+        return True
+
+    # Un motif sans separateur vise un nom de fichier ou de dossier, a
+    # n'importe quelle profondeur : `_articles_seed.py` doit s'ecrire tel quel,
+    # sans que l'auteur ait a connaitre le chemin complet.
+    return "/" not in motif and fnmatch(PurePosixPath(candidat).name, motif)
+
+
+def parse_patterns(contenu: str) -> list[str]:
+    """Extraire les motifs d'un contenu de fichier d'exclusion.
+
+    Les lignes vides et les commentaires (`#`) sont ignores, les espaces de
+    bordure retires.
+
+    Args:
+        contenu: Contenu brut du fichier.
+
+    Returns:
+        Liste des motifs, dans l'ordre de declaration.
+    """
+    motifs: list[str] = []
+    for ligne in contenu.splitlines():
+        nettoyee = ligne.strip()
+        if not nettoyee or nettoyee.startswith(COMMENT_PREFIX):
+            continue
+        motifs.append(nettoyee)
+    return motifs
+
+
+def parse_inline_patterns(valeur: str) -> list[str]:
+    """Extraire les motifs passes en ligne de commande ou par l'action.
+
+    Accepte les separateurs virgule et saut de ligne, pour qu'un `with:` YAML
+    sur plusieurs lignes et un `--exclude-paths a,b` donnent le meme resultat.
+
+    Args:
+        valeur: Motifs concatenes.
+
+    Returns:
+        Liste des motifs, dans l'ordre de declaration.
+    """
+    motifs: list[str] = []
+    for fragment in valeur.replace("\n", ",").split(","):
+        nettoye = fragment.strip()
+        if nettoye and not nettoye.startswith(COMMENT_PREFIX):
+            motifs.append(nettoye)
+    return motifs
+
+
+def load_ignore(root: Path, extra_patterns: Iterable[str] = ()) -> ScanIgnore:
+    """Charger les exclusions applicables a une racine de scan.
+
+    Fusionne le `.llm-scan-ignore` du depot analyse, s'il existe, avec les
+    motifs fournis par l'appelant. Le fichier est lu depuis le depot scanne :
+    un balayage d'organisation respecte donc les exclusions de chaque depot sans
+    configuration centrale.
+
+    Args:
+        root: Racine du scan.
+        extra_patterns: Motifs supplementaires, par exemple ceux de l'action.
+
+    Returns:
+        Les exclusions a appliquer.
+    """
+    motifs: list[str] = []
+
+    fichier = root / IGNORE_FILENAME
+    try:
+        contenu = fichier.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        # Absent est le cas courant, illisible est un accident : ni l'un ni
+        # l'autre ne doit empecher le scan de tourner.
+        pass
+    else:
+        motifs.extend(parse_patterns(contenu))
+
+    motifs.extend(motif for motif in extra_patterns if motif)
+
+    if motifs:
+        logger.info("Exclusions de scan actives : %s", ", ".join(motifs))
+
+    return ScanIgnore(patterns=tuple(motifs))

--- a/src/scanner.py
+++ b/src/scanner.py
@@ -4,9 +4,15 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from src.models import ScanMatch, ScanResult
 from src.patterns import find_matches_in_line
+from src.scan_ignore import ScanIgnore, load_ignore
+
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 
 logger = logging.getLogger(__name__)
@@ -89,12 +95,24 @@ def _should_skip_dir(dirname: str) -> bool:
     return dirname in EXCLUDED_DIRS or dirname.endswith(".egg-info")
 
 
-def scan_directory(scan_path: Path, repo_name: str) -> ScanResult:
+def scan_directory(
+    scan_path: Path,
+    repo_name: str,
+    *,
+    extra_ignore_patterns: Iterable[str] = (),
+) -> ScanResult:
     """Scan a directory tree for LLM model references.
+
+    Les exclusions declarees par le depot analyse (`.llm-scan-ignore` a sa
+    racine) sont chargees ici, et non par l'appelant : tout point d'entree du
+    scanner les respecte donc, y compris le balayage d'organisation qui clone
+    des depots dont il ne connait pas la configuration.
 
     Args:
         scan_path: Root directory to scan.
         repo_name: Name of the repository (used in results).
+        extra_ignore_patterns: Motifs d'exclusion supplementaires, fusionnes
+            avec ceux du depot.
 
     Returns:
         ScanResult with deduplicated matches.
@@ -102,20 +120,45 @@ def scan_directory(scan_path: Path, repo_name: str) -> ScanResult:
     seen: set[tuple[str, str, str]] = set()  # (model, file, match_type) for dedup
     matches: list[ScanMatch] = []
 
-    for file_path in _walk_files(scan_path):
+    ignore = load_ignore(scan_path, extra_ignore_patterns)
+    files, ignored_paths = _walk_files(scan_path, ignore)
+
+    for file_path in files:
         relative_path = str(file_path.relative_to(scan_path))
         _scan_file(file_path, relative_path, seen, matches)
+
+    # Une exclusion qui n'est pas dite est une exclusion invisible : sans cette
+    # trace, un motif trop large ferait taire des pans entiers du depot et le
+    # scan sortirait « 0 modele deprecie » avec la meme assurance que s'il
+    # avait tout lu. Les chemins sont nommes, pas seulement comptes, parce que
+    # c'est le nom qui permet de voir qu'un motif a mordu trop large.
+    if ignored_paths:
+        logger.info(
+            "Excluded from %s by scan exclusions: %s",
+            repo_name,
+            ", ".join(ignored_paths),
+        )
 
     logger.info("Scanned %s: found %d unique matches", repo_name, len(matches))
     return ScanResult(repo_name=repo_name, matches=matches)
 
 
-def _walk_files(root: Path) -> list[Path]:
-    """Walk directory tree returning scannable files (iterative)."""
+def _walk_files(root: Path, ignore: ScanIgnore | None = None) -> tuple[list[Path], list[str]]:
+    """Walk directory tree returning scannable files (iterative).
+
+    Returns:
+        Le couple (fichiers a scanner, chemins ecartes par une exclusion). Un
+        dossier exclu compte pour un seul chemin, celui du dossier : il n'est
+        pas parcouru. Les fichiers ecartes par une regle du scanner lui-meme
+        (extension, taille, dossier exclu en dur) ne sont pas listes, ce ne
+        sont pas des decisions du depot.
+    """
     files: list[Path] = []
+    ignored: list[str] = []
+    exclusions = ignore or ScanIgnore()
 
     if not root.is_dir():
-        return files
+        return files, ignored
 
     stack: list[Path] = [root]
     while stack:
@@ -125,15 +168,25 @@ def _walk_files(root: Path) -> list[Path]:
         except OSError:
             continue
         for item in children:
+            relative = item.relative_to(root).as_posix()
             if item.is_dir():
-                if not _should_skip_dir(item.name):
-                    stack.append(item)
+                if _should_skip_dir(item.name):
+                    continue
+                # Un dossier exclu n'est pas parcouru du tout : inutile de
+                # descendre pour rejeter chaque fichier un par un.
+                if exclusions.matches(relative):
+                    ignored.append(f"{relative}/")
+                    continue
+                stack.append(item)
             elif (
                 item.is_file() and _should_scan_file(item) and item.stat().st_size <= MAX_FILE_SIZE
             ):
+                if exclusions.matches(relative):
+                    ignored.append(relative)
+                    continue
                 files.append(item)
 
-    return files
+    return files, sorted(ignored)
 
 
 def _is_minified(file_path: Path) -> bool:

--- a/tests/features/scan_ignore.feature
+++ b/tests/features/scan_ignore.feature
@@ -1,0 +1,96 @@
+Feature: Scan exclusions declared by the scanned repository
+  A repository can declare, in a .llm-scan-ignore file at its root, the paths
+  that hold data rather than configuration. The scanner matches strings, not
+  meaning, so prose quoting a model name is indistinguishable from a model
+  being configured.
+
+  Scenario: A file listed in .llm-scan-ignore is not scanned
+    Given a temporary directory with the following files:
+      | path              | content                                        |
+      | config.py         | MODEL = "gpt-4o"                               |
+      | seed_articles.py  | TLDR = "il faut migrer vers o4-mini avant juin"|
+      | .llm-scan-ignore  | seed_articles.py                               |
+    When I scan the directory for repo "test-repo"
+    Then I should find 1 scan matches
+    And the results should contain model "gpt-4o"
+
+  Scenario: A bare filename excludes that file at any depth
+    Given a temporary directory with the following files:
+      | path                          | content            |
+      | src/app.py                    | model = "gpt-4o"   |
+      | src/data/deep/seed.py         | model = "gpt-4"    |
+      | .llm-scan-ignore              | seed.py            |
+    When I scan the directory for repo "test-repo"
+    Then I should find 1 scan matches
+    And the results should contain model "gpt-4o"
+
+  Scenario: A directory pattern excludes everything under it
+    Given a temporary directory with the following files:
+      | path                       | content              |
+      | src/app.py                 | model = "gpt-4o"     |
+      | fixtures/a.py              | model = "gpt-4"      |
+      | fixtures/nested/b.py       | model = "gpt-4-turbo"|
+      | .llm-scan-ignore           | fixtures/            |
+    When I scan the directory for repo "test-repo"
+    Then I should find 1 scan matches
+    And the results should contain model "gpt-4o"
+
+  Scenario: A glob pattern excludes matching files
+    Given a temporary directory with the following files:
+      | path                  | content            |
+      | src/app.py            | model = "gpt-4o"   |
+      | src/app_seed.py       | model = "gpt-4"    |
+      | .llm-scan-ignore      | *_seed.py          |
+    When I scan the directory for repo "test-repo"
+    Then I should find 1 scan matches
+    And the results should contain model "gpt-4o"
+
+  Scenario: Comments and blank lines are ignored in the exclusion file
+    Given a temporary directory with the following files:
+      | path              | content                                       |
+      | src/app.py        | model = "gpt-4o"                              |
+      | src/seed.py       | model = "gpt-4"                               |
+      | .llm-scan-ignore  | # donnee de veille, pas de la config\n\nseed.py |
+    When I scan the directory for repo "test-repo"
+    Then I should find 1 scan matches
+    And the results should contain model "gpt-4o"
+
+  Scenario: Without an exclusion file every file is still scanned
+    Given a temporary directory with the following files:
+      | path              | content            |
+      | src/app.py        | model = "gpt-4o"   |
+      | src/seed.py       | model = "gpt-4"    |
+    When I scan the directory for repo "test-repo"
+    Then I should find 2 scan matches
+
+  Scenario: Patterns passed by the action add to those of the repository
+    Given a temporary directory with the following files:
+      | path              | content            |
+      | src/app.py        | model = "gpt-4o"   |
+      | src/seed.py       | model = "gpt-4"    |
+      | .llm-scan-ignore  | seed.py            |
+    When I scan the directory for repo "test-repo" excluding "src/app.py"
+    Then I should find 0 scan matches
+
+  Scenario: An unreadable exclusion file does not stop the scan
+    Given a temporary directory with the following files:
+      | path        | content          |
+      | src/app.py  | model = "gpt-4o" |
+    And the exclusion file is a directory
+    When I scan the directory for repo "test-repo"
+    Then I should find 1 scan matches
+
+  Scenario Outline: Pattern matching against a relative path
+    Given the exclusion patterns "<patterns>"
+    Then the path "<path>" should be <verdict>
+
+    Examples:
+      | patterns          | path                        | verdict  |
+      | seed.py           | src/data/seed.py            | excluded |
+      | seed.py           | src/data/seed_other.py      | kept     |
+      | src/data/         | src/data/deep/seed.py       | excluded |
+      | src/data          | src/database.py             | kept     |
+      | *.json            | data/registry.json          | excluded |
+      | docs/*.md         | docs/guide.md               | excluded |
+      | data              | src/data_seed.py            | kept     |
+      | /                 | src/app.py                  | kept     |

--- a/tests/test_scan_ignore.py
+++ b/tests/test_scan_ignore.py
@@ -1,0 +1,108 @@
+"""BDD step definitions for repository-declared scan exclusions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pytest_bdd import given, parsers, scenarios, then, when
+
+from src.models import ScanResult
+from src.scan_ignore import IGNORE_FILENAME, ScanIgnore, parse_inline_patterns, parse_patterns
+from src.scanner import scan_directory
+
+
+scenarios("features/scan_ignore.feature")
+
+
+@given("the exclusion file is a directory")
+def given_unreadable_ignore_file(scan_dir: Path) -> None:
+    """Rendre le fichier d'exclusion illisible sans le supprimer."""
+    (scan_dir / IGNORE_FILENAME).mkdir(parents=True, exist_ok=True)
+
+
+@given(
+    parsers.cfparse('the exclusion patterns "{patterns}"'),
+    target_fixture="exclusions",
+)
+def given_patterns(patterns: str) -> ScanIgnore:
+    return ScanIgnore(patterns=tuple(parse_inline_patterns(patterns)))
+
+
+@when(
+    parsers.cfparse('I scan the directory for repo "{repo_name}"'),
+    target_fixture="scan_result",
+)
+def when_scan(scan_dir: Path, repo_name: str) -> ScanResult:
+    return scan_directory(scan_dir, repo_name)
+
+
+@when(
+    parsers.cfparse('I scan the directory for repo "{repo_name}" excluding "{patterns}"'),
+    target_fixture="scan_result",
+)
+def when_scan_excluding(scan_dir: Path, repo_name: str, patterns: str) -> ScanResult:
+    return scan_directory(
+        scan_dir,
+        repo_name,
+        extra_ignore_patterns=parse_inline_patterns(patterns),
+    )
+
+
+@then(parsers.cfparse("I should find {count:d} scan matches"))
+def then_match_count(scan_result: ScanResult, count: int) -> None:
+    assert scan_result.match_count == count, (
+        f"Expected {count} matches, got {scan_result.match_count}: {scan_result.matches}"
+    )
+
+
+@then(parsers.cfparse('the results should contain model "{model}"'))
+def then_contains_model(scan_result: ScanResult, model: str) -> None:
+    models = [m.model for m in scan_result.matches]
+    assert model in models, f"Expected model '{model}' in {models}"
+
+
+@then(parsers.cfparse('the path "{path}" should be {verdict}'))
+def then_path_verdict(exclusions: ScanIgnore, path: str, verdict: str) -> None:
+    attendu = verdict == "excluded"
+    assert exclusions.matches(path) is attendu, (
+        f"Pattern(s) {exclusions.patterns} on '{path}': expected {verdict}"
+    )
+
+
+def test_parse_patterns_ignores_comments_and_blanks():
+    contenu = "# un commentaire\n\n  seed.py  \nfixtures/\n\t# encore un\n"
+    assert parse_patterns(contenu) == ["seed.py", "fixtures/"]
+
+
+def test_parse_inline_patterns_accepts_commas_and_newlines():
+    assert parse_inline_patterns("a.py, b.py\nc/*.md") == ["a.py", "b.py", "c/*.md"]
+
+
+def test_empty_ignore_is_falsy():
+    assert not ScanIgnore()
+    assert ScanIgnore(patterns=("seed.py",))
+
+
+def test_empty_ignore_excludes_nothing():
+    """Sans motif, aucun chemin ne doit etre ecarte.
+
+    C'est le cas de tous les depots qui ne declarent rien : si `matches`
+    repondait vrai pour un chemin quelconque, le scanner se tairait partout
+    sans qu'aucun depot ait demande quoi que ce soit.
+    """
+    vide = ScanIgnore()
+    assert not vide.matches("src/app.py")
+    assert not vide.matches("")
+
+
+def test_ignore_file_itself_is_never_scanned(tmp_path: Path):
+    """Le fichier d'exclusion cite des chemins, jamais des modeles.
+
+    Il n'a pas d'extension scannable, mais rien ne le dit explicitement : ce
+    test fige la garantie, pour qu'ajouter l'extension vide a la liste des
+    fichiers scannables ne transforme pas la liste d'exclusions en source de
+    faux positifs.
+    """
+    (tmp_path / IGNORE_FILENAME).write_text("# model = gpt-4o\n", encoding="utf-8")
+    resultat = scan_directory(tmp_path, "test-repo")
+    assert resultat.match_count == 0


### PR DESCRIPTION
## Le probleme

Le scanner compare des chaines de caracteres, pas du sens. Il ne distingue pas `model = \"o4-mini\"` d'une phrase de prose qui cite `o4-mini`, et aucune heuristique generique ne fera cette distinction de facon fiable. Jusqu'ici, il n'existait aucun moyen de le lui dire : ni fichier d'exclusion, ni input d'action.

Cas concret : [baseline-automation#1091](https://github.com/Baseline-quebec/baseline-automation/issues/1091). Le fichier `_articles_seed.py` contient les resumes d'une revue de veille en IA ; l'un d'eux rapporte le retrait de GPT-4o par OpenAI et cite `o4-mini` dans sa phrase. Le scanner a ouvert une issue de depreciation sur un depot dont toute la vigie tourne deja sur Anthropic (`f/bgy/common/ai_models.py`), et l'aurait rouverte les 1er et 15 de chaque mois. Le meme fichier declenchait une seconde issue sur `gpt-4o`.

## Ce que fait cette PR

Le depot analyse declare lui-meme ses exclusions dans un **`.llm-scan-ignore`** a sa racine, au format gitignore simplifie :

\`\`\`gitignore
# Resumes d'articles de veille : citent des modeles en prose, pas en config.
src/baseline_automation/windmill/f/bgy/ingestion/_articles_seed.py
tests/fixtures/
*_seed.py
\`\`\`

| Motif | Couvre |
|---|---|
| \`seed.py\` | ce nom de fichier a n'importe quelle profondeur |
| \`fixtures/\` | ce dossier et son contenu, qui n'est meme pas parcouru |
| \`src/data/seed.py\` | ce chemin precis |
| \`*_seed.py\`, \`docs/*.md\` | globs |

Le fichier est charge par \`scan_directory\`, pas par l'appelant : **tout point d'entree en herite**, y compris le balayage mensuel de l'organisation, qui clone des depots dont il ne connait pas la configuration. Aucune configuration centrale a tenir a jour.

L'action expose aussi un \`exclude-paths\` (virgules ou sauts de ligne), en dernier recours. Le README dit explicitement de preferer le fichier : une exclusion versionnee dans le depot qu'elle concerne se relit avec lui, alors qu'une exclusion posee dans le workflow est invisible depuis le code qu'elle fait taire.

## Le risque, et ce qui le contient

Une exclusion peut faire taire un vrai modele deprecie, et un scan muet ressemble a un scan propre. Chaque chemin ecarte est donc **nomme** dans le journal, pas seulement compte : c'est le nom qui permet de reperer un motif qui a mordu trop large.

## Verification

Bout en bout sur le fichier reel de baseline-automation :

| | References | Modeles deprecies |
|---|---|---|
| Sans exclusion | 7 | 2 (\`gpt-4o\`, \`o4-mini\`) |
| Avec \`.llm-scan-ignore\` | 2 | 0 |
| Via \`--exclude-paths\` | 2 | 0 |

Les deux references restantes sont les modeles Anthropic legitimes de \`ai_models.py\` : l'exclusion ne rend pas le depot aveugle.

Suite : 526 tests verts (dont 15 nouveaux scenarios BDD), \`scan_ignore.py\` a 100 % de couverture, ruff et mypy --strict propres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)