### PR TITLE
fix: honorer le fichier .llm-scan-ignore des depots scannes

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,39 @@ configuré, le journal le dit explicitement au lieu de laisser un code d'erreur 
 
 Les issues sont désactivées par défaut sur les forks GitHub. L'action échouera si elle détecte des modèles dépréciés mais ne peut pas créer d'issues. Activez les issues dans **Settings > General > Features > Issues** du repo.
 
+### Exclure des chemins avec `.llm-scan-ignore`
+
+Un dépôt peut nommer des modèles sans en appeler un seul : offres de service,
+audits, comptes rendus, SOW. Le nom du modèle y décrit la solution proposée au
+client ou l'existant audité, pas une configuration. Le scanner ne peut pas
+trancher depuis le texte ; le dépôt, lui, le sait. Il le déclare dans un fichier
+`.llm-scan-ignore` **à sa racine**.
+
+Syntaxe réduite de `.gitignore` :
+
+| Ligne | Effet |
+|---|---|
+| `# commentaire` | ignorée, comme les lignes vides |
+| `*` | exclut tout le dépôt |
+| `docs/` ou `docs` | exclut le dossier et tout ce qui se trouve dessous |
+| `*.md` | exclut ce nom à n'importe quelle profondeur |
+| `ODS/Mandat/*` | motif avec séparateur : ancré à la racine du dépôt |
+| `!src/` | réinjecte un chemin exclu par une règle précédente |
+
+L'ordre compte : la dernière règle qui correspond gagne. Un dépôt de documents
+qui héberge aussi du code s'écrit donc ainsi, et pas dans l'autre sens.
+
+```
+# Ce dépôt ne contient que des documents de mandat, sauf src/ qui appelle un modèle.
+*
+!src/
+```
+
+Une exclusion large rend le code du dépôt invisible au scanner : une dépréciation
+ne lèvera plus rien. Écrire dans le fichier ce qui doit déclencher son retrait
+(l'arrivée de code qui appelle réellement un modèle) évite de le découvrir le jour
+de l'arrêt du modèle.
+
 ---
 
 ## Développement et maintenance du repo
@@ -443,7 +476,7 @@ data/
   registry.json          # Registre JSON des modeles deprecies
 src/
   patterns.py            # Patterns regex pour la detection de modeles
-  scanner.py             # Parcours de repertoire et scan de fichiers
+  scanner.py             # Parcours de repertoire, exclusions .llm-scan-ignore, scan
   models.py              # Modeles de donnees (ScanMatch, ScanResult)
   deprecations.py        # Chargement du registre + gestion des suffixes de date
   deprecation_feed.py    # Flux live depuis deprecations.info

--- a/src/scanner.py
+++ b/src/scanner.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
+from fnmatch import fnmatchcase
 from pathlib import Path
 
 from src.models import ScanMatch, ScanResult
@@ -76,6 +78,28 @@ SCANNABLE_FILENAMES: frozenset[str] = frozenset(
 # Max file size to scan (1 MB)
 MAX_FILE_SIZE: int = 1_048_576
 
+# Fichier d'exclusion depose a la racine du depot scanne.
+#
+# Un depot peut contenir des noms de modeles sans contenir un seul appel de
+# modele : offres de service, audits, comptes rendus. Un nom de modele y decrit
+# la solution proposee au client ou l'existant audite, jamais une configuration.
+# Le scanner ne peut pas trancher depuis le texte ; le depot, lui, le sait, et
+# l'ecrit dans ce fichier.
+IGNORE_FILE_NAME = ".llm-scan-ignore"
+
+
+@dataclass(frozen=True)
+class IgnoreRule:
+    """Une ligne du fichier d'exclusion.
+
+    `negated` porte les lignes prefixees de `!`, qui reinjectent un chemin exclu
+    par une regle precedente. C'est ce qui rend exprimable le cas « tout ce
+    depot est de la documentation, sauf ce dossier de code ».
+    """
+
+    pattern: str
+    negated: bool
+
 
 def _should_scan_file(path: Path) -> bool:
     """Determine if a file should be scanned based on extension and name."""
@@ -87,6 +111,63 @@ def _should_scan_file(path: Path) -> bool:
 def _should_skip_dir(dirname: str) -> bool:
     """Determine if a directory should be skipped."""
     return dirname in EXCLUDED_DIRS or dirname.endswith(".egg-info")
+
+
+def load_ignore_rules(scan_path: Path) -> list[IgnoreRule]:
+    """Lit les regles d'exclusion a la racine du depot scanne.
+
+    Syntaxe reduite de .gitignore : une regle par ligne, `#` en commentaire,
+    lignes vides ignorees, `!` pour reinjecter. Un fichier absent ou illisible
+    ne donne aucune regle : l'exclusion est une option, pas un prerequis.
+    """
+    ignore_file = scan_path / IGNORE_FILE_NAME
+    try:
+        content = ignore_file.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return []
+
+    rules: list[IgnoreRule] = []
+    for raw_line in content.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        negated = line.startswith("!")
+        pattern = line[1:].strip() if negated else line
+        if pattern:
+            rules.append(IgnoreRule(pattern=pattern, negated=negated))
+
+    if rules:
+        logger.info("%s: %d regle(s) d'exclusion chargee(s)", IGNORE_FILE_NAME, len(rules))
+    return rules
+
+
+def _rule_matches(relative_path: str, pattern: str) -> bool:
+    """Vrai si un chemin relatif POSIX est vise par une regle d'exclusion."""
+    target = pattern.rstrip("/")
+    if not target:
+        return False
+    # `docs/` comme `docs` visent aussi tout ce qui se trouve dessous.
+    if fnmatchcase(relative_path, target) or fnmatchcase(relative_path, f"{target}/*"):
+        return True
+    # Une regle sans separateur vise un nom, a n'importe quelle profondeur :
+    # `*.md` exclut la documentation partout, `Mandat` exclut chaque dossier qui
+    # porte ce nom. Une regle avec separateur reste ancree a la racine.
+    if "/" not in target:
+        return any(fnmatchcase(part, target) for part in relative_path.split("/"))
+    return False
+
+
+def is_ignored(relative_path: str, rules: list[IgnoreRule]) -> bool:
+    """Applique les regles dans l'ordre du fichier ; la derniere qui matche gagne.
+
+    L'ordre compte, comme dans .gitignore : `*` suivi de `!src/` exclut tout le
+    depot sauf le code, alors que l'ordre inverse n'exclurait plus rien.
+    """
+    ignored = False
+    for rule in rules:
+        if _rule_matches(relative_path, rule.pattern):
+            ignored = not rule.negated
+    return ignored
 
 
 def scan_directory(scan_path: Path, repo_name: str) -> ScanResult:
@@ -101,11 +182,18 @@ def scan_directory(scan_path: Path, repo_name: str) -> ScanResult:
     """
     seen: set[tuple[str, str, str]] = set()  # (model, file, match_type) for dedup
     matches: list[ScanMatch] = []
+    rules = load_ignore_rules(scan_path)
+    ignored_files = 0
 
     for file_path in _walk_files(scan_path):
-        relative_path = str(file_path.relative_to(scan_path))
+        relative_path = file_path.relative_to(scan_path).as_posix()
+        if is_ignored(relative_path, rules):
+            ignored_files += 1
+            continue
         _scan_file(file_path, relative_path, seen, matches)
 
+    if ignored_files:
+        logger.info("%s: %d fichier(s) exclu(s) du scan", IGNORE_FILE_NAME, ignored_files)
     logger.info("Scanned %s: found %d unique matches", repo_name, len(matches))
     return ScanResult(repo_name=repo_name, matches=matches)
 

--- a/tests/features/scanner.feature
+++ b/tests/features/scanner.feature
@@ -77,3 +77,58 @@ Feature: Repository file scanner
     And the results should contain model "gpt-4o"
     And the results should contain model "claude-3-opus"
     And the results should contain model "gpt-4-turbo"
+
+  Scenario: Scanner honore l'exclusion complete declaree par le depot
+    Given a temporary directory with the following files:
+      | path                | content                                        |
+      | .llm-scan-ignore    | # depot d'offres de service\n*                 |
+      | ODS/audit.md        | La solution proposee utilise le modele gpt-4o. |
+      | ODS/Mandat/sow.md   | model = "claude-3-opus"                        |
+    When I scan the directory for repo "test-repo"
+    Then I should find 0 scan matches
+
+  Scenario: Une reinjection garde le code scanne dans un depot exclu
+    Given a temporary directory with the following files:
+      | path              | content                                        |
+      | .llm-scan-ignore  | *\n!src/                                       |
+      | ODS/audit.md      | La solution proposee utilise le modele gpt-4o. |
+      | src/client.py     | MODEL = "gpt-4o"                               |
+    When I scan the directory for repo "test-repo"
+    Then I should find 1 scan matches
+    And the results should contain model "gpt-4o"
+
+  Scenario: Une regle de dossier exclut tout ce qui se trouve dessous
+    Given a temporary directory with the following files:
+      | path                 | content                  |
+      | .llm-scan-ignore     | docs/                    |
+      | docs/deep/spec.md    | model = "gpt-4o"         |
+      | app.py               | MODEL = "claude-3-opus"  |
+    When I scan the directory for repo "test-repo"
+    Then I should find 1 scan matches
+    And the results should contain model "claude-3-opus"
+
+  Scenario: Une regle sans separateur vise un nom a toute profondeur
+    Given a temporary directory with the following files:
+      | path                 | content                  |
+      | .llm-scan-ignore     | *.md                     |
+      | ODS/Mandat/audit.md  | model = "gpt-4o"         |
+      | app.py               | MODEL = "claude-3-opus"  |
+    When I scan the directory for repo "test-repo"
+    Then I should find 1 scan matches
+    And the results should contain model "claude-3-opus"
+
+  Scenario: Une ligne commentee n'exclut rien
+    Given a temporary directory with the following files:
+      | path              | content            |
+      | .llm-scan-ignore  | # *\n\n            |
+      | app.py            | MODEL = "gpt-4o"   |
+    When I scan the directory for repo "test-repo"
+    Then I should find 1 scan matches
+    And the results should contain model "gpt-4o"
+
+  Scenario: Un depot sans fichier d'exclusion reste scanne en entier
+    Given a temporary directory with the following files:
+      | path              | content            |
+      | app.py            | MODEL = "gpt-4o"   |
+    When I scan the directory for repo "test-repo"
+    Then I should find 1 scan matches


### PR DESCRIPTION
## Probleme

Le depot `Baseline-quebec/Ventes` ne contient que des offres de service, des audits et des SOW. Un nom de modele y decrit la solution proposee au client ou l'existant audite, jamais une configuration d'appel d'API. Le depot le declarait deja dans un `.llm-scan-ignore` a sa racine, avec le raisonnement et la condition de retrait de l'exclusion. Le scanner, lui, n'a jamais lu ce fichier : les issues #146 a #150, puis #155 a #159, portent toutes sur ce meme contenu.

## Changement

`src/scanner.py` lit `.llm-scan-ignore` a la racine du depot scanne, en syntaxe reduite de `.gitignore` :

- `#` en commentaire, lignes vides ignorees
- `*` exclut tout le depot
- `docs/` ou `docs` exclut le dossier et tout ce qui se trouve dessous
- `*.md` vise un nom a n'importe quelle profondeur ; un motif avec separateur reste ancre a la racine
- `!src/` reinjecte un chemin exclu par une regle precedente

La derniere regle qui correspond gagne, comme dans git. Les regles ne servent pas a elaguer le parcours de repertoires : une reinjection sous un dossier exclu doit rester atteignable, donc le filtre agit par fichier, avant toute lecture.

## Verification

6 scenarios ajoutes a `tests/features/scanner.feature` : exclusion complete, reinjection du code dans un depot exclu, regle de dossier, regle de nom a toute profondeur, ligne commentee sans effet, depot sans fichier d'exclusion inchange. Suite complete verte (511 tests), ruff et mypy propres.

## Suivi

Les issues #155 a #159 de `Baseline-quebec/Ventes` sont fermees comme faux positifs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)