### PR TITLE
fix: lire le .llm-scan-ignore des sous-dossiers, pas seulement de la racine

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ contient de la donnée, des fixtures ou de la veille technologique déclenchera
 donc des faux positifs qui reviennent à chaque passage.
 
 Le dépôt scanné déclare lui-même ce qui n'est pas de la configuration, dans un
-fichier **`.llm-scan-ignore`** à sa racine :
+fichier **`.llm-scan-ignore`**, à sa racine ou dans n'importe quel sous-dossier :
 
 ```gitignore
 # Résumés d'articles de veille : citent des noms de modèles en prose,
@@ -422,6 +422,17 @@ lieu de produire un « 0 modèle déprécié » qui aurait l'air d'un scan compl
 
 Le fichier est lu depuis le dépôt analysé, y compris lors du balayage mensuel
 de l'organisation : aucune configuration centrale à tenir à jour.
+
+**Un fichier placé dans un sous-dossier ne vaut que pour ce sous-arbre**, et ses
+motifs sont relatifs à ce dossier, comme un `.gitignore`. `Mandat/` écrit dans
+`ODS/.llm-scan-ignore` désigne `ODS/Mandat`, pas le `Mandat/` de la racine. Un
+fichier d'exclusion reste donc valide quand son dossier est déplacé — c'est
+précisément ce qui avait manqué : le `.llm-scan-ignore` de `Ventes` excluait tout
+le dépôt jusqu'à ce qu'une remontée de racine le range sous `ODS/`, et les cinq
+issues de faux positifs sont revenues sur les mêmes offres de service.
+
+Un dossier déjà écarté par la racine n'est pas ouvert du tout : le fichier
+d'exclusion qu'il contiendrait n'a alors rien à ajouter.
 
 En dernier recours, l'action accepte aussi un `exclude-paths`, qui s'ajoute au
 fichier du dépôt :

--- a/src/scan_ignore.py
+++ b/src/scan_ignore.py
@@ -12,21 +12,24 @@ issue de depreciation sur un depot dont tout le code tourne deja sur Anthropic,
 et l'aurait rouverte a chaque passage.
 
 Le depot analyse declare donc lui-meme ce qui n'est pas de la configuration,
-dans un fichier `.llm-scan-ignore` a sa racine. C'est une decision explicite,
-versionnee et relisible, plutot qu'une heuristique qui deciderait a sa place.
+dans un fichier `.llm-scan-ignore`. C'est une decision explicite, versionnee et
+relisible, plutot qu'une heuristique qui deciderait a sa place.
+
+Ce fichier est lu a la racine du depot ET dans n'importe quel sous-dossier, ou
+ses motifs ne valent que pour ce sous-arbre, comme un `.gitignore`. Sans cela,
+la declaration est perdue des que l'arborescence bouge. Cas reel du 2026-08-18
+dans Ventes : la PR #154 a remonte la racine du depot d'un niveau, le
+`.llm-scan-ignore` qui excluait tout s'est retrouve dans `ODS/`, et les cinq
+issues #155 a #159 sont revenues sur les memes offres de service.
 """
 
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterable
 from dataclasses import dataclass
 from fnmatch import fnmatch
 from pathlib import Path, PurePosixPath
-from typing import TYPE_CHECKING
-
-
-if TYPE_CHECKING:
-    from collections.abc import Iterable
 
 
 logger = logging.getLogger(__name__)
@@ -37,14 +40,40 @@ COMMENT_PREFIX = "#"
 
 
 @dataclass(frozen=True)
+class SubtreeIgnore:
+    """Motifs declares dans un sous-dossier, valables pour ce sous-arbre seul.
+
+    `base` est le chemin du dossier qui porte le fichier, relatif a la racine du
+    scan. Les motifs sont compares au chemin **relatif a ce dossier** : un
+    fichier d'exclusion parle de ce qui l'entoure, pas de l'arborescence
+    complete au-dessus de lui, et il reste donc valide quand le dossier est
+    deplace.
+    """
+
+    base: str
+    patterns: tuple[str, ...]
+
+
+@dataclass(frozen=True)
 class ScanIgnore:
     """Ensemble de motifs d'exclusion applique aux chemins scannes."""
 
     patterns: tuple[str, ...] = ()
+    subtrees: tuple[SubtreeIgnore, ...] = ()
 
     def __bool__(self) -> bool:
         """Vrai si au moins un motif est defini."""
-        return bool(self.patterns)
+        return bool(self.patterns) or any(sous.patterns for sous in self.subtrees)
+
+    def with_subtree(self, base: str, patterns: Iterable[str]) -> ScanIgnore:
+        """Retourne les memes exclusions, augmentees de celles d'un sous-dossier."""
+        motifs = tuple(patterns)
+        if not motifs:
+            return self
+        return ScanIgnore(
+            patterns=self.patterns,
+            subtrees=(*self.subtrees, SubtreeIgnore(base=base, patterns=motifs)),
+        )
 
     def matches(self, relative_path: str) -> bool:
         """Vrai si le chemin, ou l'un de ses dossiers parents, est exclu.
@@ -58,10 +87,11 @@ class ScanIgnore:
         Returns:
             True si un motif couvre ce chemin.
         """
+        chemin_normalise = relative_path.replace("\\", "/")
         if not self.patterns:
-            return False
+            return self._subtree_matches(chemin_normalise)
 
-        chemin = PurePosixPath(relative_path.replace("\\", "/"))
+        chemin = PurePosixPath(chemin_normalise)
         # Exclure un dossier doit exclure tout ce qu'il contient : on teste le
         # chemin lui-meme puis chacun de ses ancetres, sans quoi `docs/` ne
         # couvrirait pas `docs/veille/articles.py`.
@@ -70,9 +100,23 @@ class ScanIgnore:
             parent.as_posix() for parent in chemin.parents if parent.as_posix() != "."
         )
 
-        return any(
+        if any(
             _motif_couvre(motif, candidat) for motif in self.patterns for candidat in candidats
-        )
+        ):
+            return True
+
+        return self._subtree_matches(chemin_normalise)
+
+    def _subtree_matches(self, relative_path: str) -> bool:
+        """Vrai si un fichier d'exclusion d'un sous-dossier couvre ce chemin."""
+        for sous in self.subtrees:
+            prefixe = f"{sous.base}/"
+            if not relative_path.startswith(prefixe):
+                continue
+            interne = ScanIgnore(patterns=sous.patterns)
+            if interne.matches(relative_path[len(prefixe) :]):
+                return True
+        return False
 
 
 def _motif_couvre(motif: str, candidat: str) -> bool:
@@ -133,6 +177,24 @@ def parse_inline_patterns(valeur: str) -> list[str]:
     return motifs
 
 
+def read_ignore_file(directory: Path) -> list[str]:
+    """Lire les motifs du `.llm-scan-ignore` d'un dossier, s'il en porte un.
+
+    Args:
+        directory: Dossier susceptible de contenir le fichier.
+
+    Returns:
+        Les motifs declares, ou une liste vide si le fichier est absent ou
+        illisible : absent est le cas courant, illisible est un accident, et ni
+        l'un ni l'autre ne doit empecher le scan de tourner.
+    """
+    try:
+        contenu = (directory / IGNORE_FILENAME).read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return []
+    return parse_patterns(contenu)
+
+
 def load_ignore(root: Path, extra_patterns: Iterable[str] = ()) -> ScanIgnore:
     """Charger les exclusions applicables a une racine de scan.
 
@@ -148,18 +210,7 @@ def load_ignore(root: Path, extra_patterns: Iterable[str] = ()) -> ScanIgnore:
     Returns:
         Les exclusions a appliquer.
     """
-    motifs: list[str] = []
-
-    fichier = root / IGNORE_FILENAME
-    try:
-        contenu = fichier.read_text(encoding="utf-8", errors="ignore")
-    except OSError:
-        # Absent est le cas courant, illisible est un accident : ni l'un ni
-        # l'autre ne doit empecher le scan de tourner.
-        pass
-    else:
-        motifs.extend(parse_patterns(contenu))
-
+    motifs: list[str] = read_ignore_file(root)
     motifs.extend(motif for motif in extra_patterns if motif)
 
     if motifs:

--- a/src/scanner.py
+++ b/src/scanner.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 
 from src.models import ScanMatch, ScanResult
 from src.patterns import find_matches_in_line
-from src.scan_ignore import ScanIgnore, load_ignore
+from src.scan_ignore import ScanIgnore, load_ignore, read_ignore_file
 
 
 if TYPE_CHECKING:
@@ -170,10 +170,11 @@ def scan_directory(
 ) -> ScanResult:
     """Scan a directory tree for LLM model references.
 
-    Les exclusions declarees par le depot analyse (`.llm-scan-ignore` a sa
-    racine) sont chargees ici, et non par l'appelant : tout point d'entree du
-    scanner les respecte donc, y compris le balayage d'organisation qui clone
-    des depots dont il ne connait pas la configuration.
+    Les exclusions declarees par le depot analyse (`.llm-scan-ignore`, a sa
+    racine ou dans n'importe quel sous-dossier) sont chargees ici, et non par
+    l'appelant : tout point d'entree du scanner les respecte donc, y compris le
+    balayage d'organisation qui clone des depots dont il ne connait pas la
+    configuration.
 
     Args:
         scan_path: Root directory to scan.
@@ -213,6 +214,11 @@ def scan_directory(
 def _walk_files(root: Path, ignore: ScanIgnore | None = None) -> tuple[list[Path], list[str]]:
     """Walk directory tree returning scannable files (iterative).
 
+    Un `.llm-scan-ignore` rencontre dans un sous-dossier est charge en descendant,
+    avant que les enfants de ce dossier ne soient examines, et ses motifs ne
+    valent que pour ce sous-arbre. Un dossier deja exclu n'est pas ouvert, donc
+    un fichier d'exclusion qu'il contiendrait n'a rien a dire de plus.
+
     Returns:
         Le couple (fichiers a scanner, chemins ecartes par une exclusion). Un
         dossier exclu compte pour un seul chemin, celui du dossier : il n'est
@@ -230,6 +236,15 @@ def _walk_files(root: Path, ignore: ScanIgnore | None = None) -> tuple[list[Path
     stack: list[Path] = [root]
     while stack:
         current = stack.pop()
+        if current != root:
+            # Les motifs d'un sous-dossier sont portes par leur prefixe, donc les
+            # ajouter aux exclusions communes ne peut pas mordre ailleurs dans
+            # l'arborescence.
+            base = current.relative_to(root).as_posix()
+            motifs = read_ignore_file(current)
+            if motifs:
+                logger.info("Exclusions declarees dans %s : %s", base, ", ".join(motifs))
+                exclusions = exclusions.with_subtree(base, motifs)
         try:
             children = sorted(current.iterdir(), reverse=True)
         except OSError:

--- a/tests/features/scan_ignore.feature
+++ b/tests/features/scan_ignore.feature
@@ -94,3 +94,38 @@ Feature: Scan exclusions declared by the scanned repository
       | docs/*.md         | docs/guide.md               | excluded |
       | data              | src/data_seed.py            | kept     |
       | /                 | src/app.py                  | kept     |
+
+  # Regression du 2026-08-18 dans Ventes : la PR #154 a remonte la racine du
+  # depot d'un niveau, le fichier d'exclusion s'est retrouve dans ODS/, et les
+  # issues #155 a #159 sont revenues sur les memes offres de service.
+  Scenario: An exclusion file in a subdirectory covers that subtree
+    Given a temporary directory with the following files:
+      | path                  | content                                       |
+      | ODS/.llm-scan-ignore  | # offres de service, pas de la configuration\n* |
+      | ODS/Evolia/audit.md   | Le systeme audite utilise le modele gpt-4o.   |
+      | ODS/note.md           | model = "gemini-pro"                          |
+      | formations/app.py     | MODEL = "claude-3-opus"                       |
+    When I scan the directory for repo "test-repo"
+    Then I should find 1 scan matches
+    And the results should contain model "claude-3-opus"
+
+  Scenario: Patterns of a subdirectory are relative to that subdirectory
+    Given a temporary directory with the following files:
+      | path                  | content                  |
+      | ODS/.llm-scan-ignore  | Mandat/                  |
+      | ODS/Mandat/sow.md     | model = "gpt-4o"         |
+      | Mandat/app.py         | MODEL = "claude-3-opus"  |
+    When I scan the directory for repo "test-repo"
+    Then I should find 1 scan matches
+    And the results should contain model "claude-3-opus"
+
+  Scenario: A subdirectory already excluded at the root is not reopened
+    Given a temporary directory with the following files:
+      | path                  | content            |
+      | .llm-scan-ignore      | ODS/               |
+      | ODS/.llm-scan-ignore  | *.py               |
+      | ODS/audit.md          | model = "gpt-4o"   |
+      | app.py                | MODEL = "gpt-4"    |
+    When I scan the directory for repo "test-repo"
+    Then I should find 1 scan matches
+    And the results should contain model "gpt-4"

--- a/tests/test_scan_ignore.py
+++ b/tests/test_scan_ignore.py
@@ -106,3 +106,46 @@ def test_ignore_file_itself_is_never_scanned(tmp_path: Path):
     (tmp_path / IGNORE_FILENAME).write_text("# model = gpt-4o\n", encoding="utf-8")
     resultat = scan_directory(tmp_path, "test-repo")
     assert resultat.match_count == 0
+
+
+def test_subtree_patterns_apply_only_under_their_base():
+    """Les motifs d'un sous-dossier ne debordent pas sur un dossier voisin.
+
+    `ODS/.llm-scan-ignore` contenant `*` exclut tout le contenu de `ODS`, et rien
+    d'autre : ni la racine, ni un dossier dont le nom commence par les memes
+    lettres.
+    """
+    exclusions = ScanIgnore().with_subtree("ODS", ["*"])
+
+    assert exclusions.matches("ODS/Evolia/audit.md")
+    assert not exclusions.matches("ODS-archive/audit.md")
+    assert not exclusions.matches("formations/app.py")
+
+
+def test_subtree_patterns_are_relative_to_their_base():
+    """Un fichier d'exclusion parle de ce qui l'entoure, pas du chemin complet.
+
+    C'est ce qui le rend valide apres un deplacement du dossier : `Mandat/` ecrit
+    dans `ODS/.llm-scan-ignore` designe `ODS/Mandat`, sans que l'auteur ait a
+    connaitre la position de `ODS` dans l'arborescence.
+    """
+    exclusions = ScanIgnore().with_subtree("ODS", ["Mandat/"])
+
+    assert exclusions.matches("ODS/Mandat/sow.md")
+    assert not exclusions.matches("Mandat/app.py")
+
+
+def test_root_and_subtree_patterns_coexist():
+    exclusions = ScanIgnore(patterns=("seed.py",)).with_subtree("ODS", ["*.md"])
+
+    assert exclusions.matches("src/seed.py")
+    assert exclusions.matches("ODS/audit.md")
+    assert not exclusions.matches("src/app.py")
+    assert not exclusions.matches("ODS/app.py")
+
+
+def test_subtree_without_pattern_changes_nothing():
+    """Un fichier d'exclusion vide ou tout en commentaires ne doit rien exclure."""
+    exclusions = ScanIgnore()
+    assert exclusions.with_subtree("ODS", []) == exclusions
+    assert not exclusions.with_subtree("ODS", [])


### PR DESCRIPTION
## Probleme

Les issues #155 a #159 de `Baseline-quebec/Ventes`, ouvertes le 2026-08-18, portent sur exactement les memes fichiers que #146 a #150 : des offres de service, un audit de representation systeme, des recommandations chatbot. Ce depot avait pourtant declare son exclusion dans un `.llm-scan-ignore` (`*`), merge le 2026-08-16.

La PR #154 de Ventes (`chore: remonter la racine du depot au niveau de Ventes`) a deplace le contenu du depot sous `ODS/`, fichier d'exclusion inclus. Le scanner ne lisait que le fichier de la racine du scan : la declaration est devenue muette, et le workflow de ruleset a rouvert les cinq issues sur la PR.

## Changement

`.llm-scan-ignore` est maintenant lu dans **n'importe quel dossier**, et ses motifs ne valent que pour ce sous-arbre, compares au chemin **relatif a ce dossier** — la semantique de `.gitignore`. `Mandat/` ecrit dans `ODS/.llm-scan-ignore` designe `ODS/Mandat`, pas le `Mandat/` de la racine.

C'est le defaut de fond qui est corrige : la declaration de Ventes etait juste, mais sa portee dependait d'une position dans l'arborescence, donc un `git mv` la faisait taire sans que rien ne le signale.

Details d'implementation :

- les motifs d'un sous-arbre sont portes par leur prefixe (`SubtreeIgnore`), donc les fusionner dans les exclusions communes en descendant ne peut pas mordre sur un dossier voisin ;
- un dossier deja exclu n'est pas ouvert, donc un fichier d'exclusion qu'il contiendrait n'aurait rien a ajouter ;
- chaque fichier d'exclusion trouve est nomme dans le journal du scan, avec ses motifs.

## Verification

3 scenarios ajoutes a `tests/features/scan_ignore.feature` (dont la regression de Ventes, commentee avec sa date) et 4 tests unitaires de portee des motifs. Sans le correctif, 6 de ces tests echouent ; avec, la suite complete passe (546 tests). Ruff, ruff format et mypy propres ; couverture `scan_ignore.py` a 100 %.

## Suivi

Les issues #155 a #159 de `Baseline-quebec/Ventes` sont fermees comme faux positifs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)