### PR TITLE
fix: la prose d'un fichier Markdown n'est pas de la configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ Les issues sont désactivées par défaut sur les forks GitHub. L'action échoue
 
 ### Ce que le scanner ignore de lui-même
 
-Deux catégories n'ont pas à être déclarées : elles ne sont jamais de la
+Trois catégories n'ont pas à être déclarées : elles ne sont jamais de la
 configuration, quel que soit le dépôt.
 
 **Les journaux de changements** (`CHANGELOG`, `CHANGES`, `HISTORY`, `NEWS`,
@@ -382,6 +382,24 @@ y ouvre un titre et non un commentaire.
 Cette seconde règle corrige le plus trompeur des faux positifs : un bloc commenté
 contenant `claude-3-sonnet-20240229` avait produit l'issue la plus alarmante de
 l'organisation, sur un modèle arrêté depuis treize mois que plus rien n'appelait.
+
+**La prose des fichiers Markdown.** Markdown marque lui-même ce qui est du
+code : les clôtures ```` ``` ```` ou `~~~`, et les backticks au fil du texte.
+Hors de ces marques, un nom de modèle est cité dans une phrase, il n'y est pas
+déclaré. Une configuration réellement documentée reste vue, parce qu'on l'écrit
+en code — `MODEL="gpt-4o"` au fil d'une phrase, ou un bloc d'exemple.
+
+L'issue #77 d'`agents-support` listait trois fichiers pour `gpt-4o` : un seul le
+configurait. Les deux autres en parlaient — une fiche client résumant les
+technologies d'un mandat livré en 2024, une étude de cas racontant une bascule.
+Ni l'une ni l'autre ne se migre : corriger ce texte réécrirait un compte rendu.
+Sur l'ensemble du dépôt, la règle retire dix signalements de ce type et garde
+les trois vraies configurations.
+
+`.txt` reste hors de cette règle, faute d'une convention qui y sépare le code de
+la prose ; un fichier de notes se déclare dans `.llm-scan-ignore`. Un tableau
+Markdown dont la cellule ne porte pas de backticks est de la prose lui aussi :
+`| Modèle | gpt-4o |` n'est plus signalé, `` | Modèle | `gpt-4o` | `` l'est.
 
 ### Exclure des fichiers qui ne sont pas de la configuration
 

--- a/src/scanner.py
+++ b/src/scanner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -130,6 +131,31 @@ _MARQUEURS_COMMENTAIRE: dict[str, tuple[str, ...]] = {
     ".tsx": ("//",),
 }
 
+# Markdown marque lui-meme ce qui est du code : les clotures ``` ou ~~~, et les
+# backticks au fil du texte. Hors de ces marques, un nom de modele est cite dans
+# une phrase ; il n'y est pas declare.
+#
+# Le 2026-08-18, l'issue #77 d'agents-support listait trois fichiers pour
+# `gpt-4o`. Un seul le configurait (`cli.py`). Les deux autres en parlaient :
+# une fiche client resumant les technologies d'un mandat livre en 2024
+# (« OpenAI ChatGPT (GPT-4o / GPT-4o-mini), embeddings OpenAI »), et une etude
+# de cas racontant une bascule (« Le CHANGELOG de la version v0.4.0 porte la
+# ligne "switch to gpt-4o" »). Ni l'une ni l'autre ne se migre : corriger ce
+# texte reecrirait un compte rendu.
+#
+# Une configuration reellement documentee reste vue, parce qu'on l'ecrit en
+# code : `MODEL="gpt-4o"` au fil d'une phrase, ou un bloc cloture d'exemple.
+# `.txt` reste hors de cette regle, faute d'une convention qui y separe le code
+# de la prose ; un fichier de notes se declare dans `.llm-scan-ignore`.
+_EXTENSIONS_PROSE: frozenset[str] = frozenset({".md"})
+
+# Une cloture de bloc de code : au plus trois espaces d'indentation, puis au
+# moins trois backticks ou tildes (CommonMark).
+_CLOTURE_BLOC: re.Pattern[str] = re.compile(r"^ {0,3}(?P<marque>`{3,}|~{3,})")
+
+# Un span de code au fil du texte : n backticks, du contenu, n backticks.
+_SPAN_CODE: re.Pattern[str] = re.compile(r"(`+)(?P<code>[^`]+)\1")
+
 
 def _should_scan_file(path: Path) -> bool:
     """Determine if a file should be scanned based on extension and name."""
@@ -155,6 +181,54 @@ def _est_ligne_commentee(ligne: str, marqueurs: tuple[str, ...]) -> bool:
     ne l'appelait.
     """
     return ligne.lstrip().startswith(marqueurs)
+
+
+def _masquer_hors_code(ligne: str) -> str:
+    """Ne laisse subsister d'une ligne de prose que le contenu ecrit en code.
+
+    Le masquage remplace le reste par des espaces, donc les positions sont
+    conservees : la detection de contexte raisonne sur les caracteres voisins,
+    et un mot-cle de prose ne doit pas valider un nom de modele qui se trouve
+    dans un span de code trois mots plus loin.
+    """
+    masquee = [" "] * len(ligne)
+    for span in _SPAN_CODE.finditer(ligne):
+        debut, fin = span.span("code")
+        masquee[debut:fin] = ligne[debut:fin]
+    return "".join(masquee)
+
+
+def _reduire_markdown_au_code(lignes: list[str]) -> list[str]:
+    """Ne garde de chaque ligne markdown que ce que l'auteur a ecrit en code.
+
+    Le contenu d'un bloc cloture est rendu tel quel ; ailleurs, seuls les spans
+    entre backticks subsistent. Le nombre de lignes ne change pas, pour que le
+    numero rapporte reste celui du fichier.
+
+    Un bloc ouvert et jamais referme court jusqu'a la fin du fichier, comme le
+    veut CommonMark : mieux vaut lire un exemple de configuration jusqu'au bout
+    que de le perdre parce qu'une cloture manque.
+    """
+    reduites: list[str] = []
+    cloture: str | None = None
+
+    for ligne in lignes:
+        marque = _CLOTURE_BLOC.match(ligne)
+        if cloture is None:
+            if marque is not None:
+                cloture = marque.group("marque")
+                reduites.append("")
+            else:
+                reduites.append(_masquer_hors_code(ligne))
+            continue
+        ouverture = marque.group("marque") if marque is not None else ""
+        if ouverture.startswith(cloture[0]) and len(ouverture) >= len(cloture):
+            cloture = None
+            reduites.append("")
+        else:
+            reduites.append(ligne)
+
+    return reduites
 
 
 def _should_skip_dir(dirname: str) -> bool:
@@ -297,9 +371,14 @@ def _scan_file(
         logger.warning("Could not read %s: %s", relative_path, exc)
         return
 
-    marqueurs = _MARQUEURS_COMMENTAIRE.get(file_path.suffix.lower(), ())
+    extension = file_path.suffix.lower()
+    marqueurs = _MARQUEURS_COMMENTAIRE.get(extension, ())
 
-    for line_num, line in enumerate(content.splitlines(), start=1):
+    lignes = content.splitlines()
+    if extension in _EXTENSIONS_PROSE:
+        lignes = _reduire_markdown_au_code(lignes)
+
+    for line_num, line in enumerate(lignes, start=1):
         if marqueurs and _est_ligne_commentee(line, marqueurs):
             continue
         # Une ligne aussi longue n'est pas du code ecrit par un humain : c'est du

--- a/tests/features/scanner.feature
+++ b/tests/features/scanner.feature
@@ -135,12 +135,74 @@ Feature: Repository file scanner
       | setup.cfg   | ; model = "gpt-4o"          |
       | deploy.yml  |    # model = "gpt-4o"       |
 
-  # `#` ouvre un titre en markdown, pas un commentaire : une ligne de prose qui
-  # commence par `#` doit rester visible.
-  Scenario: A markdown heading is prose, not a comment
+  # `#` ouvre un titre en markdown, pas un commentaire : une ligne qui commence
+  # par `#` n'est pas ecartee comme du code desactive.
+  Scenario: A markdown heading is not a comment
     Given a temporary directory with the following files:
-      | path      | content                          |
-      | guide.md  | # Modeles evalues : gpt-4o       |
+      | path      | content                            |
+      | guide.md  | # Modele retenu : `gpt-4o`         |
+    When I scan the directory for repo "test-repo"
+    Then I should find 1 scan matches
+    And the results should contain model "gpt-4o"
+
+  # Hors des backticks, un nom de modele est cite dans une phrase, pas declare.
+  # Les deux premieres lignes viennent de l'issue #77 d'agents-support, qui
+  # listait trois fichiers pour `gpt-4o` : un seul le configurait.
+  Scenario Outline: A model named in markdown prose is not a configuration
+    Given a temporary directory with the following files:
+      | path        | content            |
+      | src/app.py  | model = "gpt-4o"   |
+      | <fiche>     | <prose>            |
+    When I scan the directory for repo "test-repo"
+    Then I should find 1 scan matches
+    And the results should contain model "gpt-4o"
+
+    Examples:
+      | fiche              | prose                                                                     |
+      | fiches/client.md   | Weaviate, OpenAI ChatGPT (GPT-4o / GPT-4o-mini), embeddings OpenAI        |
+      | cas/collecte.md    | Le CHANGELOG de la v0.4.0 porte la ligne « switch to gpt-4o », le         |
+      | notes.md           | On avait evalue claude-3-opus avant de trancher, dit le compte rendu      |
+
+  # Une configuration documentee s'ecrit en code : elle reste vue.
+  Scenario Outline: A model written as markdown code is a declaration
+    Given a temporary directory with the following files:
+      | path      | content     |
+      | guide.md  | <contenu>   |
+    When I scan the directory for repo "test-repo"
+    Then I should find 1 scan matches
+    And the results should contain model "gpt-4o"
+
+    Examples:
+      | contenu                                                        |
+      | Le fichier `.env` fixe `COMPLETION_MODEL="gpt-4o"` par defaut. |
+      | Configuration :\n\n```yaml\nmodel: "gpt-4o"\n```\n         |
+      | Exemple :\n\n~~~\nMODEL=gpt-4o\n~~~\n                      |
+
+  # La cloture ferme le bloc : ce qui suit redevient de la prose.
+  Scenario: Prose after a fenced block is prose again
+    Given a temporary directory with the following files:
+      | path      | content                                                            |
+      | guide.md  | ```yaml\nmodel: "gpt-4o"\n```\n\nOn avait teste gpt-4-turbo avant. |
+    When I scan the directory for repo "test-repo"
+    Then I should find 1 scan matches
+    And the results should contain model "gpt-4o"
+
+  # Une cloture plus courte que celle qui a ouvert le bloc ne le ferme pas :
+  # un bloc markdown imbrique reste du code de bout en bout.
+  Scenario: A shorter fence does not close a longer one
+    Given a temporary directory with the following files:
+      | path      | content                                              |
+      | guide.md  | ````markdown\n```yaml\nmodel: "gpt-4o"\n```\n````\n |
+    When I scan the directory for repo "test-repo"
+    Then I should find 1 scan matches
+    And the results should contain model "gpt-4o"
+
+  # `.txt` n'a pas de convention qui separe le code de la prose : la regle ne
+  # s'y applique pas, et un fichier de notes se declare dans `.llm-scan-ignore`.
+  Scenario: A text file keeps being read in full
+    Given a temporary directory with the following files:
+      | path      | content                              |
+      | notes.txt | on avait evalue gpt-4o ce jour-la    |
     When I scan the directory for repo "test-repo"
     Then I should find 1 scan matches
     And the results should contain model "gpt-4o"


### PR DESCRIPTION
Corrige les deux faux positifs de https://github.com/Baseline-quebec/agents-support/issues/77.

Markdown marque lui-meme ce qui est du code : les clotures ``` ou ~~~, et les backticks au fil du texte. Hors de ces marques, un nom de modele est cite dans une phrase, il n'y est pas declare. Le scanner ne lit donc plus, dans un `.md`, que ce que l'auteur a ecrit en code.

L'issue listait trois fichiers pour `gpt-4o`. Un seul le configurait (`cli.py`). Les deux autres en parlaient :

| Fichier | Ligne |
|---|---|
| `ventes/knowledge/fiches/hellodarwin.md` | « OpenAI ChatGPT (GPT-4o / GPT-4o-mini), embeddings OpenAI » |
| `ventes/knowledge/etudes-de-cas/laylah/collecte.md` | « Le CHANGELOG de la version v0.4.0 porte la ligne "switch to gpt-4o" » |

Ni l'une ni l'autre ne se migre : corriger ce texte reecrirait un compte rendu, comme pour les journaux de changements (#255).

Une configuration reellement documentee reste vue, parce qu'on l'ecrit en code : `MODEL="gpt-4o"` au fil d'une phrase, ou un bloc cloture d'exemple. Un bloc ouvert et jamais referme court jusqu'a la fin du fichier, comme le veut CommonMark, et une cloture plus courte que celle qui a ouvert le bloc ne le ferme pas.

`.txt` reste hors de la regle, faute d'une convention qui y separe le code de la prose ; un fichier de notes se declare dans `.llm-scan-ignore`.

## Mesure sur agents-support

13 signalements avant, 3 apres. Les dix retires sont tous de la prose :

- `appels-offres/templates/sections-soumission.md` — « [Ex. : LLM (GPT-4, Claude)] » dans un gabarit
- `rsde/knowledge/eligibilite/trois-criteres-rsde.md` — un exemple de grille d'eligibilite
- huit fiches clients et etudes de cas resumant les technologies de mandats livres

Les trois vraies configurations sont conservees, dont la seule ligne de code de l'issue.

9 scenarios ajoutes, 555 tests passent, couverture 90 % (scanner 96 %).

🤖 Generated with [Claude Code](https://claude.com/claude-code)