### PR TITLE
feat: une fixture de test n'est pas de la configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ Les issues sont désactivées par défaut sur les forks GitHub. L'action échoue
 
 ### Ce que le scanner ignore de lui-même
 
-Trois catégories n'ont pas à être déclarées : elles ne sont jamais de la
+Quatre catégories n'ont pas à être déclarées : elles ne sont jamais de la
 configuration, quel que soit le dépôt.
 
 **Les journaux de changements** (`CHANGELOG`, `CHANGES`, `HISTORY`, `NEWS`,
@@ -400,6 +400,22 @@ les trois vraies configurations.
 la prose ; un fichier de notes se déclare dans `.llm-scan-ignore`. Un tableau
 Markdown dont la cellule ne porte pas de backticks est de la prose lui aussi :
 `| Modèle | gpt-4o |` n'est plus signalé, `` | Modèle | `gpt-4o` | `` l'est.
+
+**Les fichiers et dossiers de test.** Un modèle fixé dans une fixture sert à
+faire passer un test ; il n'est appelé par aucun service, et le migrer ne change
+rien à ce qui répond en production. Un test qui épingle vraiment un modèle
+arrêté se signale d'ailleurs tout seul : la suite passe au rouge, ce qui est un
+signal plus sûr qu'une issue ouverte à côté.
+
+Sont écartés les dossiers `tests/`, `test/`, `__tests__/`, `__mocks__/` et
+`testdata/` — qui ne sont pas parcourus du tout — et, ailleurs, les fichiers
+dont le nom suit une convention de test : `conftest.py`, `test_extraction.py`,
+`pricing_test.py`, `VariantsPanel.test.tsx`, `agent.spec.ts`, `handler_test.go`.
+Le nom seul ne suffit pas : `latest_model.py`, `contest.py` et `testing_utils.py`
+restent du code qui tourne.
+
+Trois dépôts avaient une issue ouverte sur leur seul `tests/conftest.py` :
+`cmac-monorepo`, `metal-marquis-monorepo` et `tourisme-monteregie-chatbot`.
 
 ### Exclure des fichiers qui ne sont pas de la configuration
 

--- a/src/scanner.py
+++ b/src/scanner.py
@@ -69,6 +69,34 @@ EXCLUDED_STEMS: frozenset[str] = frozenset(
     }
 )
 
+# Une suite de tests n'est pas ce qui tourne. Un modele fixe dans une fixture
+# sert a faire passer un test, il n'est appele par aucun service, et le migrer
+# ne change rien a ce qui repond en production. Un test qui epingle vraiment un
+# modele arrete se signale d'ailleurs tout seul : la suite passe au rouge, ce
+# qui est un signal plus sur qu'une issue ouverte a cote.
+#
+# Le 2026-08-18, trois depots de l'organisation avaient une issue ouverte sur
+# leur seul `tests/conftest.py` : cmac-monorepo, metal-marquis-monorepo et
+# tourisme-monteregie-chatbot. Trois depots qui declareraient la meme
+# exclusion : la regle appartient au scanner.
+#
+# Un dossier de tests n'est pas parcouru du tout ; hors de ces dossiers, c'est
+# le nom du fichier qui tranche.
+EXCLUDED_TEST_DIRS: frozenset[str] = frozenset(
+    {
+        "tests",
+        "test",
+        "__tests__",
+        "__mocks__",
+        "testdata",
+    }
+)
+
+# Conventions de nommage des fichiers de test, dans les langages scannes :
+# `conftest.py`, `test_x.py`, `x_test.py`, `x.test.ts`, `x.spec.js`, `x_test.go`.
+_NOMS_DE_TEST: frozenset[str] = frozenset({"conftest.py"})
+_SUFFIXES_DE_TEST: tuple[str, ...] = (".test", ".spec")
+
 # File extensions to scan
 SCANNABLE_EXTENSIONS: frozenset[str] = frozenset(
     {
@@ -157,9 +185,27 @@ _CLOTURE_BLOC: re.Pattern[str] = re.compile(r"^ {0,3}(?P<marque>`{3,}|~{3,})")
 _SPAN_CODE: re.Pattern[str] = re.compile(r"(`+)(?P<code>[^`]+)\1")
 
 
+def _est_fichier_de_test(path: Path) -> bool:
+    """Vrai si le nom du fichier suit une convention de test.
+
+    Couvre les fichiers de test qui vivent a cote du code qu'ils testent, hors
+    d'un dossier `tests/` : `conftest.py`, `test_extraction.py`,
+    `pricing_test.py`, `VariantsPanel.test.tsx`, `agent.spec.ts`,
+    `handler_test.go`.
+    """
+    if path.name in _NOMS_DE_TEST:
+        return True
+    tige = path.stem.lower()
+    if tige.startswith("test_") or tige.endswith("_test"):
+        return True
+    return Path(tige).suffix in _SUFFIXES_DE_TEST
+
+
 def _should_scan_file(path: Path) -> bool:
     """Determine if a file should be scanned based on extension and name."""
     if path.stem.upper() in EXCLUDED_STEMS:
+        return False
+    if _est_fichier_de_test(path):
         return False
     if path.name in SCANNABLE_FILENAMES:
         return True
@@ -233,7 +279,11 @@ def _reduire_markdown_au_code(lignes: list[str]) -> list[str]:
 
 def _should_skip_dir(dirname: str) -> bool:
     """Determine if a directory should be skipped."""
-    return dirname in EXCLUDED_DIRS or dirname.endswith(".egg-info")
+    return (
+        dirname in EXCLUDED_DIRS
+        or dirname.lower() in EXCLUDED_TEST_DIRS
+        or dirname.endswith(".egg-info")
+    )
 
 
 def scan_directory(

--- a/tests/features/main.feature
+++ b/tests/features/main.feature
@@ -50,11 +50,13 @@ Feature: CLI entry point and orchestration
       | src/chatbot/embedding.py              | from openai import OpenAI\nembedding = OpenAI(model="text-embedding-ada-002")                              |
       | tests/unit_testing/test_chain.py      | mock_llm = OpenAI(model="gpt-4", temperature=0)                                                           |
     When I scan and check deprecations for repo "librairies-martin-chatbot"
-    Then I should find at least 4 deprecated references
+    Then I should find at least 3 deprecated references
     And deprecated models should include "gpt-4o-mini"
     And deprecated models should include "gpt-4o"
     And deprecated models should include "text-embedding-ada-002"
-    And deprecated models should include "gpt-4"
+    # Le `gpt-4` de la fixture ne sert qu'a faire passer un test : rien ne
+    # l'appelle, et le migrer ne change rien a ce qui repond en production.
+    And deprecated models should not include "gpt-4"
 
   Scenario: End-to-end yvan style project has no deprecations
     Given a temporary directory with the following files:

--- a/tests/features/scanner.feature
+++ b/tests/features/scanner.feature
@@ -135,6 +135,48 @@ Feature: Repository file scanner
       | setup.cfg   | ; model = "gpt-4o"          |
       | deploy.yml  |    # model = "gpt-4o"       |
 
+  # Une suite de tests n'est pas ce qui tourne : un modele fixe dans une fixture
+  # sert a faire passer un test, rien ne l'appelle. Trois depots avaient une
+  # issue ouverte sur leur seul `tests/conftest.py` le 2026-08-18 : cmac-monorepo,
+  # metal-marquis-monorepo et tourisme-monteregie-chatbot.
+  Scenario Outline: A test fixture is not configuration
+    Given a temporary directory with the following files:
+      | path        | content            |
+      | src/app.py  | model = "gpt-4o"   |
+      | <fixture>   | model = "gpt-4"    |
+    When I scan the directory for repo "test-repo"
+    Then I should find 1 scan matches
+    And the results should contain model "gpt-4o"
+
+    Examples:
+      | fixture                              |
+      | tests/conftest.py                    |
+      | apps/backend/tests/conftest.py       |
+      | test/helpers.py                      |
+      | src/__tests__/agent.ts               |
+      | src/components/Panel.test.tsx        |
+      | src/services/agent.spec.ts           |
+      | scripts/test_extraction_models.py    |
+      | src/acquisition/pricing_test.py      |
+      | internal/handler_test.go             |
+
+  # Le nom seul ne suffit pas a faire un fichier de test : `latest_model.py` ou
+  # `contest.py` restent du code qui tourne.
+  Scenario Outline: A name that merely resembles a test is still code
+    Given a temporary directory with the following files:
+      | path      | content            |
+      | <fichier> | model = "gpt-4o"   |
+    When I scan the directory for repo "test-repo"
+    Then I should find 1 scan matches
+    And the results should contain model "gpt-4o"
+
+    Examples:
+      | fichier                    |
+      | src/latest_model.py        |
+      | src/contest.py             |
+      | src/testing_utils.py       |
+      | src/protest.ts             |
+
   # `#` ouvre un titre en markdown, pas un commentaire : une ligne qui commence
   # par `#` n'est pas ecartee comme du code desactive.
   Scenario: A markdown heading is not a comment

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -256,6 +256,15 @@ def check_e2e_deprecated_includes(
     assert model in models, f"Expected '{model}' in deprecated models {models}"
 
 
+@then(parsers.cfparse('deprecated models should not include "{model}"'))
+def check_e2e_deprecated_excludes(
+    e2e_result: dict[str, list[DeprecationAlert] | list[ScanMatch]], model: str
+) -> None:
+    alerts: list[DeprecationAlert] = e2e_result["alerts"]  # type: ignore[assignment]
+    models = [a.lifecycle.model for a in alerts]
+    assert model not in models, f"'{model}' should not be reported, got {models}"
+
+
 @then(parsers.cfparse('active models should not be flagged: "{models_str}"'))
 def check_active_not_flagged(
     e2e_result: dict[str, list[DeprecationAlert] | list[ScanMatch]], models_str: str


### PR DESCRIPTION
Un modèle fixé dans une fixture sert à faire passer un test ; il n'est appelé par aucun service, et le migrer ne change rien à ce qui répond en production. Un test qui épingle vraiment un modèle arrêté se signale d'ailleurs tout seul : la suite passe au rouge, ce qui est un signal plus sûr qu'une issue ouverte à côté.

Trois dépôts de l'organisation avaient une issue ouverte sur leur **seul** `tests/conftest.py` : `cmac-monorepo#32`, `metal-marquis-monorepo#38`, `tourisme-monteregie-chatbot#114`. Trois dépôts qui déclareraient la même exclusion : la règle appartient au scanner, comme pour les journaux de changements (#255).

## Ce qui est écarté

| | |
|---|---|
| Dossiers, non parcourus | `tests/`, `test/`, `__tests__/`, `__mocks__/`, `testdata/` |
| Fichiers, ailleurs dans l'arbre | `conftest.py`, `test_extraction.py`, `pricing_test.py`, `VariantsPanel.test.tsx`, `agent.spec.ts`, `handler_test.go` |

Le nom seul ne suffit pas : `latest_model.py`, `contest.py` et `testing_utils.py` restent du code qui tourne. Un scénario le vérifie.

## Mesure sur clones frais

| Dépôt | Avant | Après | Effet |
|---|---|---|---|
| `mpa-data-bridge` | 38 sur 21 fichiers | 23 sur 14 | `claude-3-haiku` disparaît : il ne vivait que dans des tests |
| `studio` | 87 sur 70 fichiers | 79 sur 62 | `gemini-2.0-flash` disparaît (`studio#196` ne listait qu'un `VariantsPanel.test.tsx`) |
| `hubert`, `yvan` | | | seuls des `*.test.tsx` et des baselines d'éval sous `tests/fixtures/` sont retirés |

Aucune configuration de service perdue.

Le scénario de bout en bout `librairies-martin-chatbot` est mis à jour : son `tests/unit_testing/test_chain.py` épinglait `gpt-4` dans un mock, et le scénario vérifie désormais que ce `gpt-4` n'est plus rapporté.

13 scénarios ajoutés, 568 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)